### PR TITLE
Rebrand README for rand_mt

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,16 @@
+**/*
+
+!**/*/
+
+node_modules/
+target/
+
+!*.html
+!*.json
+!*.md
+!*.toml
+!*.yaml
+!*.yml
+
+**/vendor/*
+!**/vendor/*.md

--- a/README.md
+++ b/README.md
@@ -1,27 +1,33 @@
-# Mersenne Twister in Rust
+# rand_mt
 
-This is a pure rust port of the
-[Mersenne Twister](http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html)
-pseudorandom number generators. [See the rustdoc][doc] for suggested usage.
+[![GitHub Actions](https://github.com/artichoke/rand_mt/workflows/CI/badge.svg)](https://github.com/artichoke/rand_mt/actions)
+[![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
+[![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
+<br>
+[![rand_mt documentation](https://img.shields.io/badge/docs-rand__mt-blue.svg)](https://artichoke.github.io/rand_mt/rand_mt/)
 
-[doc]: https://docs.rs/mersenne_twister/
+Implemenents a selection of Mersenne Twister random number generators.
 
-## Algorithms
+> A very fast random number generator of period 2<sup>19937</sup>-1. [Makoto
+> Matsumoto, 1997]
 
-- MT19937 (32-bit version)
-- MT19937-64 (64-bit version)
+The Mersenne Twister algorithms are not suitable for cryptographic uses, but are
+ubiquitous. See the
+[Mersenne Twister website](http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html).
+A variant of Mersenne Twister is the
+[default PRNG in Ruby](https://ruby-doc.org/core-2.6.3/Random.html).
+
+This crate depends on [rand_core](https://crates.io/crates/rand_core).
+
+## `std`
+
+Mersenne Twister requires ~2.5KB of internal state. To make the RNGs implemented
+in this crate practical to embed in other structs, `rand_mt` stores state in
+boxed slices. Because of the dependency on `Box` and `Vec`, `rand_mt` requires
+`std`.
 
 ## License
 
-Licensed under either of
-
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
-  http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
-  at your option.
-
-### Contribution
-
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
-dual licensed as above, without any additional terms or conditions.
+`rand_mt` is distributed under the terms of either the
+[MIT License](/LICENSE-MIT) or the
+[Apache License (Version 2.0)](/LICENSE-APACHE).

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 Implemenents a selection of Mersenne Twister random number generators.
 
-> A very fast random number generator of period 2<sup>19937</sup>-1. [Makoto
-> Matsumoto, 1997]
+> A very fast random number generator of period 2<sup>19937</sup>-1. (Makoto
+> Matsumoto, 1997).
 
 The Mersenne Twister algorithms are not suitable for cryptographic uses, but are
 ubiquitous. See the
@@ -31,3 +31,7 @@ boxed slices. Because of the dependency on `Box` and `Vec`, `rand_mt` requires
 `rand_mt` is distributed under the terms of either the
 [MIT License](/LICENSE-MIT) or the
 [Apache License (Version 2.0)](/LICENSE-APACHE).
+
+`rand_mt` is derived from `rust-mersenne-twister` @
+[`1.1.1`](https://github.com/dcrewi/rust-mersenne-twister/tree/1.1.1) which is
+Copyright (c) 2015 rust-mersenne-twister developers.


### PR DESCRIPTION
Model README after README for rand_pcg.