### PR TITLE
Add missing constructors and other quality improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ This crate depends on [rand_core](https://crates.io/crates/rand_core).
 
 Mersenne Twister requires ~2.5KB of internal state. To make the RNGs implemented
 in this crate practical to embed in other structs, `rand_mt` stores state in
-boxed slices. Because of the dependency on `Box` and `Vec`, `rand_mt` requires
-`std`.
+boxed slices. Because of the dependency on `Box`, `rand_mt` requires `std`.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,8 @@
 //! # use rand_mt::MersenneTwister;
 //! # use rand_core::{RngCore, SeedableRng};
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! // Get a seed somehow.
-//! let seed: [u8; 8] = 0x1234_567_89ab_cdef_u64.to_ne_bytes();
+//! // Get a seed somehow, expected to be a little endian encoded `u64`.
+//! let seed: [u8; 8] = 0x1234_567_89ab_cdef_u64.to_le_bytes();
 //! // Create the default RNG.
 //! let mut rng = MersenneTwister::from_seed(seed);
 //! // start grabbing randomness from rng...


### PR DESCRIPTION
- Use little endian bytes in crate-level doc example.
- Remove double break in `fill_bytes`.
- use `bytes.len()` instead of hardcoding offsets in `fill_bytes`.
- Add public `DEFAULT_SEED` associated constant and use internally.
- Create boxed slice directly and avoid `vec!`.
- Add `MT::new` which takes a primitive `u32` or `u64` seed and
  internally converts to a byte array.
- Add `MT::new_from_slice` which creates an uninitialized MT and calls
  `reseed_from_slice`.
- Add docs to `Default::default` impl.