### PR TITLE
Make rand_mt no_std compatible

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -10,6 +10,11 @@
     "description": "Area: Core MT implementation."
   },
   {
+    "name": "A-crate-features",
+    "color": "f7e101",
+    "description": "Area: Compile-time features or attributes."
+  },
+  {
     "name": "A-deps",
     "color": "f7e101",
     "description": "Area: Source and library dependencies."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/artichoke/rand_mt"
 documentation = "https://artichoke.github.io/rand_mt/rand_mt/"
 description = "Reference Mersenne Twister random number generators"
 keywords = ["random", "rand", "rng", "mt"]
-categories = ["algorithms"]
+categories = ["algorithms", "no-std"]
 include = [
     "**/*.rs",
     "Cargo.toml",

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ A variant of Mersenne Twister is the
 
 This crate depends on [rand_core](https://crates.io/crates/rand_core).
 
-## `std`
+## Crate Features
+
+`rand_mt` is `no_std` compatible.
 
 Mersenne Twister requires ~2.5KB of internal state. To make the RNGs implemented
-in this crate practical to embed in other structs, `rand_mt` stores state in
-boxed slices. Because of the dependency on `Box`, `rand_mt` requires `std`.
+in this crate practical to embed in other structs, you may wish to store the RNG
+in a `Box`.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 #![deny(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
 #![forbid(unsafe_code)]
+#![cfg_attr(not(any(doctest, test)), no_std)]
 
 //! Mersenne Twister random number generators.
 //!
@@ -75,8 +76,6 @@
 //! despite their similar names. They produce different output streams from the
 //! same seed. You will need to pick a specific flavor of the two algorithms if
 //! portable reproducibility is important to you.
-
-#![deny(missing_docs)]
 
 pub use crate::mt19937::MT19937;
 pub use crate::mt19937_64::MT19937_64;


### PR DESCRIPTION
- manually implement traits to work around lack of const generics for large fixed size arrays.
- update docs around size
- update docs around `Box`
- update README.