### PR TITLE
Compile tests and doctests with no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 #![deny(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
 #![forbid(unsafe_code)]
-#![cfg_attr(not(any(doctest, test)), no_std)]
+#![no_std]
 
 //! Mersenne Twister random number generators.
 //!

--- a/src/mt19937.rs
+++ b/src/mt19937.rs
@@ -36,8 +36,8 @@ const LOWER_MASK: Wrapping<u32> = Wrapping(0x7fff_ffff);
 /// `MT19937` is also the same size as [`MT19937_64`](crate::MT19937_64).
 ///
 /// ```
+/// # use core::mem;
 /// # use rand_mt::{MT19937, MT19937_64};
-/// # use std::mem;
 /// assert_eq!(2504, mem::size_of::<MT19937>());
 /// assert_eq!(mem::size_of::<MT19937_64>(), mem::size_of::<MT19937>());
 /// ```
@@ -438,9 +438,9 @@ impl Default for MT19937 {
 
 #[cfg(test)]
 mod tests {
+    use core::num::Wrapping;
     use quickcheck_macros::quickcheck;
     use rand_core::{RngCore, SeedableRng};
-    use std::num::Wrapping;
 
     use super::MT19937;
     use crate::vectors::mt as vectors;
@@ -483,9 +483,9 @@ mod tests {
         for _ in 0..skip {
             orig_mt.next_u32();
         }
-        let mut samples = Vec::with_capacity(super::N);
-        for _ in 0..super::N {
-            samples.push(orig_mt.next_u32());
+        let mut samples = [0; super::N];
+        for sample in samples.iter_mut() {
+            *sample = orig_mt.next_u32();
         }
         let mut recovered_mt = MT19937::recover(&samples[..]).unwrap();
         for _ in 0..super::N * 2 {

--- a/src/mt19937.rs
+++ b/src/mt19937.rs
@@ -483,12 +483,12 @@ mod tests {
         for _ in 0..skip {
             orig_mt.next_u32();
         }
-        let mut samples = [0; super::N];
+        let mut samples = [0; 624];
         for sample in samples.iter_mut() {
             *sample = orig_mt.next_u32();
         }
         let mut recovered_mt = MT19937::recover(&samples[..]).unwrap();
-        for _ in 0..super::N * 2 {
+        for _ in 0..624 * 2 {
             if orig_mt.next_u32() != recovered_mt.next_u32() {
                 return false;
             }

--- a/src/mt19937_64.rs
+++ b/src/mt19937_64.rs
@@ -481,12 +481,12 @@ mod tests {
         for _ in 0..skip {
             orig_mt.next_u64();
         }
-        let mut samples = [0; super::NN];
+        let mut samples = [0; 312];
         for sample in samples.iter_mut() {
             *sample = orig_mt.next_u64();
         }
         let mut recovered_mt = MT19937_64::recover(&samples[..]).unwrap();
-        for _ in 0..super::NN * 2 {
+        for _ in 0..312 * 2 {
             if orig_mt.next_u64() != recovered_mt.next_u64() {
                 return false;
             }

--- a/src/mt19937_64.rs
+++ b/src/mt19937_64.rs
@@ -36,8 +36,8 @@ const LM: Wrapping<u64> = Wrapping(0x7fff_ffff); // Least significant 31 bits
 /// `MT19937_64` is also the same size as [`MT19937`](crate::MT19937).
 ///
 /// ```
+/// # use core::mem;
 /// # use rand_mt::{MT19937, MT19937_64};
-/// # use std::mem;
 /// assert_eq!(2504, mem::size_of::<MT19937_64>());
 /// assert_eq!(mem::size_of::<MT19937>(), mem::size_of::<MT19937_64>());
 /// ```
@@ -436,9 +436,9 @@ impl Default for MT19937_64 {
 
 #[cfg(test)]
 mod tests {
+    use core::num::Wrapping;
     use quickcheck_macros::quickcheck;
     use rand_core::{RngCore, SeedableRng};
-    use std::num::Wrapping;
 
     use super::MT19937_64;
     use crate::vectors::mt64 as vectors;
@@ -481,9 +481,9 @@ mod tests {
         for _ in 0..skip {
             orig_mt.next_u64();
         }
-        let mut samples = Vec::with_capacity(super::NN);
-        for _ in 0..super::NN {
-            samples.push(orig_mt.next_u64());
+        let mut samples = [0; super::NN];
+        for sample in samples.iter_mut() {
+            *sample = orig_mt.next_u64();
         }
         let mut recovered_mt = MT19937_64::recover(&samples[..]).unwrap();
         for _ in 0..super::NN * 2 {


### PR DESCRIPTION
remove `cfg_attr` that did not apply `no_std` during `test` and `doctest`.

This required repointing some `std` imports to core and replacing a `Vec` in `recovery` tests to use a stack allocated array.