### PR TITLE
Do not leak PRNG state in fmt::Debug impl

### DIFF
--- a/src/mt19937.rs
+++ b/src/mt19937.rs
@@ -49,10 +49,7 @@ pub struct MT19937 {
 
 impl fmt::Debug for MT19937 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("MT19937")
-            .field("idx", &self.idx)
-            .field("state", &&self.state[..])
-            .finish()
+        f.debug_struct("MT19937").finish()
     }
 }
 

--- a/src/mt19937_64.rs
+++ b/src/mt19937_64.rs
@@ -50,10 +50,7 @@ pub struct MT19937_64 {
 
 impl fmt::Debug for MT19937_64 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("MT19937_64")
-            .field("idx", &self.idx)
-            .field("state", &&self.state[..])
-            .finish()
+        f.debug_struct("MT19937_64").finish()
     }
 }
 


### PR DESCRIPTION
Inspired by the debug impls in rand_pcg.