### PR TITLE
Remove unwraps from documentation examples

### DIFF
--- a/src/mt.rs
+++ b/src/mt.rs
@@ -220,13 +220,16 @@ impl RngCore for Mt19937GenRand32 {
     /// ```
     /// # use rand_core::RngCore;
     /// # use rand_mt::Mt19937GenRand32;
+    /// # fn main() -> Result<(), rand_core::Error> {
     /// let mut mt = Mt19937GenRand32::new_unseeded();
     /// let mut buf = [0; 32];
-    /// mt.try_fill_bytes(&mut buf).unwrap();
+    /// mt.try_fill_bytes(&mut buf)?;
     /// assert_ne!([0; 32], buf);
     /// let mut buf = [0; 31];
-    /// mt.try_fill_bytes(&mut buf).unwrap();
+    /// mt.try_fill_bytes(&mut buf)?;
     /// assert_ne!([0; 31], buf);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {

--- a/src/mt64.rs
+++ b/src/mt64.rs
@@ -216,13 +216,16 @@ impl RngCore for Mt19937GenRand64 {
     /// ```
     /// # use rand_core::RngCore;
     /// # use rand_mt::Mt19937GenRand64;
+    /// # fn main() -> Result<(), rand_core::Error> {
     /// let mut mt = Mt19937GenRand64::new_unseeded();
     /// let mut buf = [0; 32];
-    /// mt.try_fill_bytes(&mut buf).unwrap();
+    /// mt.try_fill_bytes(&mut buf)?;
     /// assert_ne!([0; 32], buf);
     /// let mut buf = [0; 31];
-    /// mt.try_fill_bytes(&mut buf).unwrap();
+    /// mt.try_fill_bytes(&mut buf)?;
     /// assert_ne!([0; 31], buf);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {


### PR DESCRIPTION
Fixup for API guidelines C-QUESTION-MARK.
https://rust-lang.github.io/api-guidelines/documentation.html#examples-use--not-try-not-unwrap-c-question-mark