### PR TITLE
Add doc(html_root_url = ...) cfg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_mt"
-version = "2.0.0"
+version = "2.0.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["David Creswick <dcrewi@gyrae.net>", "Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
@@ -28,5 +28,7 @@ std = []
 rand_core = "0.5"
 
 [dev-dependencies]
+doc-comment = "0.3"
 quickcheck = { version = "0.9", default-features = false }
 quickcheck_macros = "0.9"
+version-sync = "0.8"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,26 @@ A variant of Mersenne Twister is the
 
 This crate depends on [rand_core](https://crates.io/crates/rand_core).
 
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+rand_core = "0.5"
+rand_mt = "2"
+```
+
+Then create a RNG like:
+
+```rust
+use rand_core::RngCore;
+use rand_mt::Mt64;
+
+let mut rng = Mt64::new_unseeded();
+assert_ne!(rng.next_u64(), rng.next_u64());
+```
+
 ## Crate Features
 
 `rand_mt` is `no_std` compatible. `rand_mt` has an optional `std` feature which

--- a/deny.toml
+++ b/deny.toml
@@ -22,7 +22,12 @@ highlight = "all"
 allow = []
 deny = []
 skip = []
-skip-tree = []
+skip-tree = [
+  { name = "proc-macro2", version = "<1.0" }, # version-check 0.8.1
+  { name = "quote", version = "<1.0" }, # version-check 0.8.1
+  { name = "syn", version = "<1.0" }, # version-check 0.8.1
+  { name = "unicode-xid", version = "<1.0" }, # version-check 0.8.1
+]
 
 [sources]
 unknown-registry = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -21,13 +21,13 @@ multiple-versions = "deny"
 highlight = "all"
 allow = []
 deny = []
-skip = []
-skip-tree = [
+skip = [
   { name = "proc-macro2", version = "<1.0" }, # version-check 0.8.1
   { name = "quote", version = "<1.0" }, # version-check 0.8.1
   { name = "syn", version = "<1.0" }, # version-check 0.8.1
   { name = "unicode-xid", version = "<1.0" }, # version-check 0.8.1
 ]
+skip-tree = []
 
 [sources]
 unknown-registry = "deny"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::cargo)]
+#![allow(clippy::multiple_crate_versions)] // version-check 0.8.1
 #![deny(missing_docs, intra_doc_link_resolution_failure)]
 #![deny(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,11 @@
 //! assert_eq!(default, mt);
 //! ```
 
+#![doc(html_root_url = "https://docs.rs/rand_mt/2.0.0")]
+
+#[cfg(doctest)]
+doc_comment::doctest!("../README.md");
+
 use core::fmt;
 
 pub use crate::mt::Mt19937GenRand32;

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -1,0 +1,9 @@
+#[test]
+fn test_readme_deps() {
+    version_sync::assert_markdown_deps_updated!("README.md");
+}
+
+#[test]
+fn test_html_root_url() {
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
+}


### PR DESCRIPTION
- Add version-sync to enforce version is kept synchronized.
- Add usage instructions to README.
- Add doc_comment to enforce usage instructions in README compile.

Addresses C-HTML-ROOT in the Rust API guidelines:
https://rust-lang.github.io/api-guidelines/documentation.html#crate-sets-html_root_url-attribute-c-html-root