### PR TITLE
Release v3.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_mt"
-version = "2.0.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "3.0.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["David Creswick <dcrewi@gyrae.net>", "Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
 rand_core = "0.5"
-rand_mt = "2"
+rand_mt = "3"
 ```
 
 Then create a RNG like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 //! assert_eq!(default, mt);
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/rand_mt/2.0.0")]
+#![doc(html_root_url = "https://docs.rs/rand_mt/3.0.0")]
 
 #[cfg(doctest)]
 doc_comment::doctest!("../README.md");


### PR DESCRIPTION
Release `rand_mt` 3.0.0. This release is a new major version and
contains breaking changes.

Changelog from 2.0.0:

- Tests and doctests compile with `no_std`.
- Improve performance of `RngCore::fill_bytes`.
- [Breaking] Change `fmt::Debug` impls to not leak internal RNG state.
- [Breaking] Remove slice-based key constructors, `Mt::new_from_slice`.
- [Breaking] Remove slice-based reseed functions,
  `Mt::reseed_from_slice`.
- [Breaking] `Mt::recover` returns `Result<Mt, RecoverRngError>` instead
  of `Option<Mt>`.
- [Breaking] Add `std` feature, enabled by default, that impls
  `std::error::Error` on `RecoverRngError`.
- Add iterator-based key constructors, `Mt::new_with_key`.
- Add iterator-based reseed functions, `Mt::reseed_with_key`.
- [Breaking] Rename RNG structs to be compliant with Rust API guidelines
  for naming. `M19937` -> `Mt19937GenRand32` and `MT19937_64` ->
  `Mt19937GenRand64`.

This release contains improvements to documentation, testing, and
release packaging. It includes the following PRs:

- GH-8
- GH-9
- GH-10
- GH-11
- GH-12
- GH-13
- GH-14
- GH-15
- GH-16
- GH-17
- GH-18
- GH-19
- GH-20
- GH-21
- GH-22
- GH-23
- GH-24