### PR TITLE
Remove actions/setup-node build step

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -25,22 +25,3 @@ jobs:
 
       - name: Run cargo-deny
         run: cargo-deny check
-
-  js:
-    name: Audit JS Dependencies
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Install Node toolchain
-        uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-
-      - name: Install Nodejs toolchain
-        run: yarn install --frozen-lockfile
-
-      - name: Yarn audit
-        run: yarn audit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,13 +82,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Node toolchain
-        uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-
-      - name: Install prettier
-        run: npm install -g prettier
+      - name: Format with prettier
+        run: npx prettier --check '**/*'
 
       - name: Format markdown with prettier
-        run: prettier --prose-wrap always --check '**/*.md' '*.md'
+        run: npx prettier --prose-wrap always --check '**/*.md' '*.md'

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,9 +6,9 @@ node_modules/
 target/
 
 !*.html
+!*.js
 !*.json
 !*.md
-!*.toml
 !*.yaml
 !*.yml
 


### PR DESCRIPTION
This step has been flaky and it is not necessary because
the GitHub Actions base image ships with node 12.x.

Remove JS audit build.
run prettier with npx for formatting text.
Add prettier ignore and format all text sources, not just markdown.