### PR TITLE
Add Zlib to license allowlist in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,8 +7,9 @@ ignore = []
 [licenses]
 unlicensed = "deny"
 allow = [
-  "MIT",
   "Apache-2.0",
+  "MIT",
+  "Zlib",
 ]
 deny = []
 copyleft = "deny"


### PR DESCRIPTION
version-sync transitively depends on tinyvec.