### PR TITLE
Replace doc_comment dev-dependency with a small inlined macro_rules macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ std = []
 rand_core = "0.5"
 
 [dev-dependencies]
-doc-comment = "0.3"
 quickcheck = { version = "0.9", default-features = false }
 quickcheck_macros = "0.9"
 version-sync = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::cargo)]
-#![allow(clippy::multiple_crate_versions)] // version-check 0.8.1
 #![deny(missing_docs, intra_doc_link_resolution_failure)]
 #![deny(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
@@ -70,8 +69,19 @@
 
 #![doc(html_root_url = "https://docs.rs/rand_mt/3.0.0")]
 
+// Ensure code blocks in README.md compile
 #[cfg(doctest)]
-doc_comment::doctest!("../README.md");
+macro_rules! readme {
+    ($x:expr) => {
+        #[doc = $x]
+        mod readme {}
+    };
+    () => {
+        readme!(include_str!("../README.md"));
+    };
+}
+#[cfg(doctest)]
+readme!();
 
 use core::fmt;
 


### PR DESCRIPTION
Remove a dev dep and avoid upgrading to doc-comment 0.4 based on proc-macros.