### PR TITLE
Add A-ruby label

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -35,6 +35,11 @@
     "description": "Area: crates.io releases and version bumps."
   },
   {
+    "name": "A-ruby",
+    "color": "f7e101",
+    "description": "Area: Compatibility with Ruby's Mersenne Twister implementation in `Random`."
+  },
+  {
     "name": "A-security",
     "color": "f7e101",
     "description": "Area: security vulnerabilities and unsoundness issues."


### PR DESCRIPTION
For tracking efforts to add a Random-compatible MT implementation. This will
allow Artichoke to use rand_mt to implement the Random class in Ruby Core.