### PR TITLE
Improve the maintainability of markdown sources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,27 @@
 # Contributing to Artichoke – rand_mt
 
-👋 Hi and welcome to [Artichoke](https://github.com/artichoke). Thanks for
-taking the time to contribute! 💪💎🙌
+👋 Hi and welcome to [Artichoke]. Thanks for taking the time to contribute!
+💪💎🙌
 
 Artichoke aspires to be a Ruby 2.6.3-compatible implementation of the Ruby
-programming language.
-[There is lots to do](https://github.com/artichoke/artichoke/issues).
+programming language. [There is lots to do].
 
 rand_mt is used to implement the default psuedorandom number generator that
-backs the [`Random` core class](https://ruby-doc.org/core-2.6.3/Random.html).
+backs the [`Random` core class].
 
 If Artichoke does not run Ruby source code in the same way that MRI does, it is
-a bug and we would appreciate if you
-[filed an issue so we can fix it](https://github.com/artichoke/artichoke/issues/new).
-[File bugs specific to rand_mt in this repository](https://github.com/artichoke/rand_mt/issues/new).
+a bug and we would appreciate if you [filed an issue so we can fix it]. [File
+bugs specific to rand_mt in this repository].
 
 If you would like to contribute code to rand_mt 👩‍💻👨‍💻, find an issue that looks
 interesting and leave a comment that you're beginning to investigate. If there
-is no issue, please file one before beginning to work on a PR.
-[Good first issues are labeled `E-easy`](https://github.com/artichoke/rand_mt/labels/E-easy).
+is no issue, please file one before beginning to work on a PR. [Good first
+issues are labeled `E-easy`].
 
 ## Discussion
 
-If you'd like to engage in a discussion outside of GitHub, you can
-[join Artichoke's public Discord server](https://discord.gg/QCe2tp2).
+If you'd like to engage in a discussion outside of GitHub, you can [join
+Artichoke's public Discord server].
 
 ## Setup
 
@@ -38,9 +36,8 @@ compiler.
 
 #### Installation
 
-The recommended way to install the Rust toolchain is with
-[rustup](https://rustup.rs/). On macOS, you can install rustup with
-[Homebrew](https://docs.brew.sh/Installation):
+The recommended way to install the Rust toolchain is with [rustup]. On macOS,
+you can install rustup with [Homebrew]:
 
 ```sh
 brew install rustup-init
@@ -72,10 +69,46 @@ toolchain installed, you can install the crates specified in
 cargo build
 ```
 
+### Ruby
+
+rand_mt optionally uses a recent Ruby 2.x and [bundler] 2.x. The
+[`.ruby-version`](.ruby-version) file in this repository specifies Ruby 2.6.6.
+
+rand_mt/ uses [`rake`](Rakefile) as a task runner. You can see the available
+tasks by running:
+
+```console
+$ bundle exec rake --tasks
+rake build                        # Build Rust workspace
+rake doc                          # Generate Rust API documentation
+rake doc:open                     # Generate Rust API documentation and open it in a web browser
+rake fmt                          # Format sources
+rake fmt:rust                     # Format Rust sources with rustfmt
+rake fmt:text                     # Format text, YAML, and Markdown sources with prettier
+rake format                       # Format sources
+rake format:rust                  # Format Rust sources with rustfmt
+rake format:text                  # Format text, YAML, and Markdown sources with prettier
+rake lint                         # Lint sources
+rake lint:clippy                  # Lint Rust sources with Clippy
+rake lint:clippy:restriction      # Lint Rust sources with Clippy restriction pass (unenforced lints)
+rake lint:rubocop                 # Run RuboCop
+rake lint:rubocop:auto_correct    # Auto-correct RuboCop offenses
+rake release:markdown_link_check  # Check for broken links in markdown files
+rake test                         # Run rand_mt unit tests
+```
+
+To lint Ruby sources, rand_mt uses [RuboCop]. RuboCop runs as part of the `lint`
+task. To run RuboCop by itself, invoke the `lint:rubocop` task.
+
+```console
+$ bundle exec rake lint
+$ bundle exec rake lint:rubocop
+```
+
 ### Node.js
 
 Node.js is an optional dependency that is used for formatting text sources with
-[prettier](https://prettier.io/).
+[prettier].
 
 Node.js is only required for formatting if modifying the following filetypes:
 
@@ -83,11 +116,8 @@ Node.js is only required for formatting if modifying the following filetypes:
 - `yaml`
 - `yml`
 
-You will need to install
-[Node.js](https://nodejs.org/en/download/package-manager/).
-
-On macOS, you can install Node.js with
-[Homebrew](https://docs.brew.sh/Installation):
+You will need to install [Node.js]. On macOS, you can install Node.js with
+[Homebrew]:
 
 ```sh
 brew install node
@@ -98,27 +128,24 @@ brew install node
 To lint and format Rust sources run:
 
 ```sh
-cargo fmt
-touch src/lib.rs
-cargo clippy --all-targets --all-features
+bundle exec rake fmt:rust lint:clippy
 ```
 
 To lint and format text sources run:
 
 ```sh
-npx prettier --write '**/*'
+bundle exec rake fmt:text
 ```
 
 ## Testing
 
-A PR must have new or existing tests for it to be merged. The
-[Rust book chapter on testing](https://doc.rust-lang.org/book/ch11-00-testing.html)
-is a good place to start.
+A PR must have new or existing tests for it to be merged. The [Rust book chapter
+on testing] is a good place to start.
 
 To run tests:
 
 ```sh
-cargo test
+bundle exec rake test # or `cargo test`
 ```
 
 `cargo test` accepts a filter argument that will limit test execution to tests
@@ -137,12 +164,32 @@ Tests are run for every PR. All builds must pass before merging a PR.
 Version specifiers in `Cargo.toml` are NPM caret-style by default. A version
 specifier of `4.1.2` means `4.1.2 <= version < 5.0.0`.
 
-To see what crates are outdated, you can use
-[cargo-outdated](https://github.com/kbknapp/cargo-outdated).
+To see what crates are outdated, you can use [cargo-outdated].
 
 If you need to pull in an updated version of a crate for a bugfix or a new
 feature, update the version number in `Cargo.toml`. See
-[Artichoke GH-548](https://github.com/artichoke/artichoke/pull/548) for an
-example.
+[artichoke/artichoke#548] for an example.
 
-Regular dependency bumps are handled by [@dependabot](https://dependabot.com/).
+Regular dependency bumps are handled by [@dependabot].
+
+[artichoke]: https://github.com/artichoke
+[there is lots to do]: https://github.com/artichoke/artichoke/issues
+[`random` core class]: https://ruby-doc.org/core-2.6.3/Random.html
+[filed an issue so we can fix it]:
+  https://github.com/artichoke/artichoke/issues/new
+[file bugs specific to rand_mt in this repository]:
+  https://github.com/artichoke/rand_mt/issues/new
+[good first issues are labeled `e-easy`]:
+  https://github.com/artichoke/rand_mt/labels/E-easy
+[join artichoke's public discord server]: https://discord.gg/QCe2tp2
+[rustup]: https://rustup.rs/
+[homebrew]: https://docs.brew.sh/Installation
+[bundler]: https://bundler.io/
+[rubocop]: https://github.com/rubocop-hq/rubocop
+[prettier]: https://prettier.io/
+[node.js]: https://nodejs.org/en/download/package-manager/
+[rust book chapter on testing]:
+  https://doc.rust-lang.org/book/ch11-00-testing.html
+[cargo-outdated]: https://github.com/kbknapp/cargo-outdated
+[artichoke/artichoke#548]: https://github.com/artichoke/artichoke/pull/548
+[@dependabot]: https://dependabot.com/

--- a/README.md
+++ b/README.md
@@ -14,12 +14,10 @@ Implemenents a selection of Mersenne Twister random number generators.
 > Matsumoto, 1997).
 
 The Mersenne Twister algorithms are not suitable for cryptographic uses, but are
-ubiquitous. See the
-[Mersenne Twister website](http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html).
-A variant of Mersenne Twister is the
-[default PRNG in Ruby](https://ruby-doc.org/core-2.6.3/Random.html).
+ubiquitous. See the [Mersenne Twister website]. A variant of Mersenne Twister is
+the [default PRNG in Ruby].
 
-This crate depends on [rand_core](https://crates.io/crates/rand_core).
+This crate depends on [rand_core].
 
 ## Usage
 
@@ -53,9 +51,14 @@ in a `Box`.
 ## License
 
 `rand_mt` is distributed under the terms of either the
-[MIT License](/LICENSE-MIT) or the
-[Apache License (Version 2.0)](/LICENSE-APACHE).
+[MIT License](LICENSE-MIT) or the
+[Apache License (Version 2.0)](LICENSE-APACHE).
 
-`rand_mt` is derived from `rust-mersenne-twister` @
-[`1.1.1`](https://github.com/dcrewi/rust-mersenne-twister/tree/1.1.1) which is
-Copyright (c) 2015 rust-mersenne-twister developers.
+`rand_mt` is derived from `rust-mersenne-twister` @ [`1.1.1`] which is Copyright
+(c) 2015 rust-mersenne-twister developers.
+
+[mersenne twister website]:
+  http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
+[default prng in ruby]: https://ruby-doc.org/core-2.6.3/Random.html
+[rand_core]: https://crates.io/crates/rand_core
+[`1.1.1`]: https://github.com/dcrewi/rust-mersenne-twister/tree/1.1.1


### PR DESCRIPTION
- Move links to end of doc via named anchors.
- Add Ruby section to contributing.
- Update contributing for rake task runner.