### PR TITLE
Derive Hash, PartialEq, Eq, PartialOrd, Ord on mersenne twister RNGs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,37 @@ jobs:
       - name: Test with no default features
         run: cargo test --no-default-features
 
+  build-msrv:
+    name: Build (1.47.0)
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: "1.47.0"
+          profile: minimal
+
+      - name: Compile
+        run: cargo build --verbose
+
+      - name: Compile tests
+        run: cargo test --no-run
+
+      - name: Test
+        run: cargo test
+
+      - name: Test with all features
+        run: cargo test --all-features
+
+      - name: Test with no default features
+        run: cargo test --no-default-features
+
   rust:
     name: Lint and format Rust
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Mersenne Twister requires ~2.5KB of internal state. To make the RNGs implemented
 in this crate practical to embed in other structs, you may wish to store the RNG
 in a `Box`.
 
+### Minimum Supported Rust Version
+
+This crate requires at least Rust 1.47.0. This version can be bumped in minor
+releases.
+
 ## License
 
 `rand_mt` is distributed under the terms of either the

--- a/src/mt.rs
+++ b/src/mt.rs
@@ -9,10 +9,8 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use core::cmp::Ordering;
 use core::convert::TryFrom;
 use core::fmt;
-use core::hash;
 use core::num::Wrapping;
 
 use rand_core::{RngCore, SeedableRng};
@@ -47,46 +45,16 @@ const LOWER_MASK: Wrapping<u32> = Wrapping(0x7fff_ffff);
 /// assert_eq!(2504, mem::size_of::<Mt19937GenRand32>());
 /// assert_eq!(mem::size_of::<Mt19937GenRand64>(), mem::size_of::<Mt19937GenRand32>());
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(clippy::module_name_repetitions)]
 pub struct Mt19937GenRand32 {
     idx: usize,
     state: [Wrapping<u32>; N],
 }
 
-impl Eq for Mt19937GenRand32 {}
-
-impl PartialEq for Mt19937GenRand32 {
-    fn eq(&self, other: &Self) -> bool {
-        self.state[..] == other.state[..] && self.idx == other.idx
-    }
-}
-
-impl Ord for Mt19937GenRand32 {
-    fn cmp(&self, other: &Self) -> Ordering {
-        match self.state[..].cmp(&other.state[..]) {
-            Ordering::Equal => self.idx.cmp(&other.idx),
-            ordering => ordering,
-        }
-    }
-}
-
-impl PartialOrd for Mt19937GenRand32 {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl hash::Hash for Mt19937GenRand32 {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.idx.hash(state);
-        self.state.hash(state);
-    }
-}
-
 impl fmt::Debug for Mt19937GenRand32 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Mt19937GenRand32 {{}}")
+        f.write_str("Mt19937GenRand64 {}")
     }
 }
 

--- a/src/mt64.rs
+++ b/src/mt64.rs
@@ -9,10 +9,8 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use core::cmp::Ordering;
 use core::convert::TryFrom;
 use core::fmt;
-use core::hash;
 use core::num::Wrapping;
 
 use rand_core::{RngCore, SeedableRng};
@@ -45,45 +43,15 @@ const LM: Wrapping<u64> = Wrapping(0x7fff_ffff); // Least significant 31 bits
 /// assert_eq!(2504, mem::size_of::<Mt19937GenRand64>());
 /// assert_eq!(mem::size_of::<Mt19937GenRand32>(), mem::size_of::<Mt19937GenRand64>());
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Mt19937GenRand64 {
     idx: usize,
     state: [Wrapping<u64>; NN],
 }
 
-impl Eq for Mt19937GenRand64 {}
-
-impl PartialEq for Mt19937GenRand64 {
-    fn eq(&self, other: &Self) -> bool {
-        self.state[..] == other.state[..] && self.idx == other.idx
-    }
-}
-
-impl Ord for Mt19937GenRand64 {
-    fn cmp(&self, other: &Self) -> Ordering {
-        match self.state[..].cmp(&other.state[..]) {
-            Ordering::Equal => self.idx.cmp(&other.idx),
-            ordering => ordering,
-        }
-    }
-}
-
-impl PartialOrd for Mt19937GenRand64 {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl hash::Hash for Mt19937GenRand64 {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.idx.hash(state);
-        self.state.hash(state);
-    }
-}
-
 impl fmt::Debug for Mt19937GenRand64 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Mt19937GenRand64 {{}}")
+        f.write_str("Mt19937GenRand64 {}")
     }
 }
 


### PR DESCRIPTION
- Add a statement documenting `rand_mt`'s minimum supported Rust version
  to the README.
- Bump the MSRV to 1.47.0, which lifted the `LengthAtMost32` restriction
  on generic array length impls.
- Add a (unenforced) CI job for testing `rand_mt` with Rust 1.47.0.
- Derive `Hash`, `PartialEq`, `Eq`, `PartialOrd`, `Ord` on
  `Mt19937GenRand32`.
- Derive `Hash`, `PartialEq`, `Eq`, `PartialOrd`, `Ord` on
  `Mt19937GenRand34`.
- Remove the `write!` macro from the `core::fmt::Debug` impls on
  `Mt19937GenRand32` and `Mt19937GenRand64`, preferring to use
  `fmt::Formatter::write_str` instead.