### PR TITLE
Make the dependency on rand_core optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,13 @@ include = [
 ]
 
 [features]
-default = ["std"]
+default = ["rand-traits", "std"]
+rand-traits = ["rand_core"]
 # Enables `std::error::Error` impls.
 std = []
 
 [dependencies]
-rand_core = "0.5"
+rand_core = { version = "0.5", default-features = false, optional = true }
 
 [dev-dependencies]
 quickcheck = { version = "0.9", default-features = false }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ The Mersenne Twister algorithms are not suitable for cryptographic uses, but are
 ubiquitous. See the [Mersenne Twister website]. A variant of Mersenne Twister is
 the [default PRNG in Ruby].
 
-This crate depends on [rand_core].
+This crate optionally depends on [rand_core] and implements `RngCore` on the
+RNGs in this crate.
 
 ## Usage
 
@@ -25,14 +26,12 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rand_core = "0.5"
 rand_mt = "3"
 ```
 
 Then create a RNG like:
 
 ```rust
-use rand_core::RngCore;
 use rand_mt::Mt64;
 
 let mut rng = Mt64::new_unseeded();
@@ -41,8 +40,13 @@ assert_ne!(rng.next_u64(), rng.next_u64());
 
 ## Crate Features
 
-`rand_mt` is `no_std` compatible. `rand_mt` has an optional `std` feature which
-is enabled by default that adds `std::error::Error` impls when enabled.
+`rand_mt` is `no_std` compatible. `rand_mt` has several optional features that
+are enabled by default:
+
+- **rand-traits** - Enables a dependency on [`rand_core`]. Activating this
+  feature implements `RngCore` and `SeedableRng` on the RNGs in this crate.
+- **std** - Enables a dependency on the Rust Standard Library. Activating this
+  feature enables [`std::error::Error`] impls on error types in this crate.
 
 Mersenne Twister requires ~2.5KB of internal state. To make the RNGs implemented
 in this crate practical to embed in other structs, you may wish to store the RNG
@@ -66,4 +70,6 @@ releases.
   http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
 [default prng in ruby]: https://ruby-doc.org/core-2.6.3/Random.html
 [rand_core]: https://crates.io/crates/rand_core
+[`rand_core`]: https://crates.io/crates/rand_core
+[`std::error::error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 [`1.1.1`]: https://github.com/dcrewi/rust-mersenne-twister/tree/1.1.1

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -2,7 +2,6 @@
 extern crate test;
 
 mod mt19937 {
-    use rand_core::RngCore;
     use rand_mt::Mt;
 
     #[bench]
@@ -23,7 +22,6 @@ mod mt19937 {
 }
 
 mod mt19937_64 {
-    use rand_core::RngCore;
     use rand_mt::Mt64;
 
     #[bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
 #![warn(unused_qualifications)]
 #![warn(variant_size_differences)]
 #![forbid(unsafe_code)]
-#![cfg_attr(not(feature = "std"), no_std)]
 
 //! Mersenne Twister random number generators.
 //!
@@ -44,22 +43,17 @@
 //! Both RNGs implement a `recover` constructor which can reconstruct the RNG
 //! state from a sequence of output samples.
 //!
-//! ## Usage
+//! # Usage
 //!
 //! You can seed a RNG and begin sampling it:
 //!
 //! ```
-//! # use rand_core::{RngCore, SeedableRng};
 //! # use rand_mt::Mt64;
-//! # fn example() -> Result<(), rand_core::Error> {
 //! // Create the RNG.
 //! let mut rng = Mt64::new(0x1234_567_89ab_cdef_u64);
 //! // start grabbing randomness from rng...
 //! let mut buf = vec![0; 512];
-//! rng.try_fill_bytes(&mut buf)?;
-//! # Ok(())
-//! # }
-//! # example().unwrap()
+//! rng.fill_bytes(&mut buf);
 //! ```
 //!
 //! Or if you want to use the default (fixed) seeds that are specified in the
@@ -71,8 +65,27 @@
 //! let mt = Mt::new_unseeded();
 //! assert_eq!(default, mt);
 //! ```
+//!
+//! # Crate Features
+//!
+//! `rand_mt` is `no_std` compatible. `rand_mt` has several optional features
+//! that are enabled by default:
+//!
+//! - **rand-traits** - Enables a dependency on [`rand_core`]. Activating this
+//!   feature implements `RngCore` and `SeedableRng` on the RNGs in this crate.
+//! - **std** - Enables a dependency on the Rust Standard Library. Activating
+//!   this feature enables [`std::error::Error`] impls on error types in this
+//!   crate.
+//!
+//! Mersenne Twister requires ~2.5KB of internal state. To make the RNGs
+//! implemented in this crate practical to embed in other structs, you may wish
+//! to store the RNG in a `Box`.
+//!
+//! [`rand_core`]: https://crates.io/crates/rand_core
+//! [`std::error::error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 
 #![doc(html_root_url = "https://docs.rs/rand_mt/3.0.0")]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]

--- a/src/mt/rand.rs
+++ b/src/mt/rand.rs
@@ -1,0 +1,170 @@
+use rand_core::{Error, RngCore, SeedableRng};
+
+use super::Mt19937GenRand32;
+
+impl SeedableRng for Mt19937GenRand32 {
+    type Seed = [u8; 4];
+
+    /// Reseed from a little endian encoded `u32`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rand_core::{RngCore, SeedableRng};
+    /// use rand_mt::Mt19937GenRand32;
+    ///
+    /// // Default MT seed
+    /// let seed = 5489_u32.to_le_bytes();
+    /// let mut rng = Mt19937GenRand32::from_seed(seed);
+    /// # fn example<T: RngCore>(mut rng: T) {
+    /// assert_ne!(rng.next_u32(), rng.next_u32());
+    /// # }
+    /// # example(rng);
+    /// ```
+    #[inline]
+    fn from_seed(seed: Self::Seed) -> Self {
+        Self::from(seed)
+    }
+}
+
+impl RngCore for Mt19937GenRand32 {
+    /// Generate next `u64` output.
+    ///
+    /// This function is implemented by generating two `u32`s from the RNG and
+    /// shifting + masking them into a `u64` output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rand_core::RngCore;
+    /// use rand_mt::Mt19937GenRand32;
+    ///
+    /// let mut rng = Mt19937GenRand32::new_unseeded();
+    /// # fn example<T: RngCore>(mut rng: T) {
+    /// assert_ne!(rng.next_u64(), rng.next_u64());
+    /// # }
+    /// # example(rng);
+    /// ```
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        Self::next_u64(self)
+    }
+
+    /// Generate next `u32` output.
+    ///
+    /// `u32` is the native output of the generator. This function advances the
+    /// RNG step counter by one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rand_core::RngCore;
+    /// use rand_mt::Mt19937GenRand32;
+    ///
+    /// let mut rng = Mt19937GenRand32::new_unseeded();
+    /// # fn example<T: RngCore>(mut rng: T) {
+    /// assert_ne!(rng.next_u32(), rng.next_u32());
+    /// # }
+    /// # example(rng);
+    /// ```
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        Self::next_u32(self)
+    }
+
+    /// Fill a buffer with bytes generated from the RNG.
+    ///
+    /// This method generates random `u32`s (the native output unit of the RNG)
+    /// until `dest` is filled.
+    ///
+    /// This method may discard some output bits if `dest.len()` is not a
+    /// multiple of 4.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rand_core::RngCore;
+    /// use rand_mt::Mt19937GenRand32;
+    ///
+    /// let mut rng = Mt19937GenRand32::new_unseeded();
+    /// # fn example<T: RngCore>(mut rng: T) {
+    /// let mut buf = [0; 32];
+    /// rng.fill_bytes(&mut buf);
+    /// assert_ne!([0; 32], buf);
+    /// let mut buf = [0; 31];
+    /// rng.fill_bytes(&mut buf);
+    /// assert_ne!([0; 31], buf);
+    /// # }
+    /// # example(rng);
+    /// ```
+    #[inline]
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        Self::fill_bytes(self, dest)
+    }
+
+    /// Fill a buffer with bytes generated from the RNG.
+    ///
+    /// This method generates random `u32`s (the native output unit of the RNG)
+    /// until `dest` is filled.
+    ///
+    /// This method may discard some output bits if `dest.len()` is not a
+    /// multiple of 4.
+    ///
+    /// `try_fill_bytes` is implemented with [`fill_bytes`](RngCore::fill_bytes)
+    /// and is infallible.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rand_core::RngCore;
+    /// use rand_mt::Mt19937GenRand32;
+    ///
+    /// let mut rng = Mt19937GenRand32::new_unseeded();
+    /// # fn example<T: RngCore>(mut rng: T) -> Result<(), rand_core::Error> {
+    /// let mut buf = [0; 32];
+    /// rng.try_fill_bytes(&mut buf)?;
+    /// assert_ne!([0; 32], buf);
+    /// let mut buf = [0; 31];
+    /// rng.try_fill_bytes(&mut buf)?;
+    /// assert_ne!([0; 31], buf);
+    /// # Ok(())
+    /// # }
+    /// # example(rng).unwrap()
+    /// ```
+    #[inline]
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        Self::fill_bytes(self, dest);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::num::Wrapping;
+    use rand_core::{RngCore, SeedableRng};
+
+    use super::Mt19937GenRand32;
+    use crate::vectors::mt::{STATE_SEEDED_BY_U32, TEST_OUTPUT};
+
+    #[test]
+    fn seeded_state_from_u32_seed() {
+        let rng = Mt19937GenRand32::new(0x1234_5678_u32);
+        let rng_from_seed = Mt19937GenRand32::from_seed(0x1234_5678_u32.to_le_bytes());
+        assert_eq!(rng.state, rng_from_seed.state);
+        for (&Wrapping(x), &y) in rng.state.iter().zip(STATE_SEEDED_BY_U32.iter()) {
+            assert_eq!(x, y);
+        }
+        for (&Wrapping(x), &y) in rng_from_seed.state.iter().zip(STATE_SEEDED_BY_U32.iter()) {
+            assert_eq!(x, y);
+        }
+    }
+
+    #[test]
+    fn output_from_u32_slice_key() {
+        let key = [0x123_u32, 0x234_u32, 0x345_u32, 0x456_u32];
+        let mut rng = Mt19937GenRand32::new_with_key(key.iter().copied());
+        for &x in TEST_OUTPUT.iter() {
+            assert_eq!(x, RngCore::next_u32(&mut rng));
+        }
+    }
+}

--- a/src/mt64/rand.rs
+++ b/src/mt64/rand.rs
@@ -1,0 +1,166 @@
+use rand_core::{Error, RngCore, SeedableRng};
+
+use super::Mt19937GenRand64;
+
+impl SeedableRng for Mt19937GenRand64 {
+    type Seed = [u8; 8];
+
+    /// Reseed from a little endian encoded `u64`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use rand_core::{RngCore, SeedableRng};
+    /// # use rand_mt::Mt19937GenRand64;
+    /// // Default MT seed
+    /// let seed = 5489_u64.to_le_bytes();
+    /// let mut mt = Mt19937GenRand64::from_seed(seed);
+    /// assert_ne!(mt.next_u64(), mt.next_u64());
+    /// ```
+    #[inline]
+    fn from_seed(seed: Self::Seed) -> Self {
+        Self::from(seed)
+    }
+}
+
+impl RngCore for Mt19937GenRand64 {
+    /// Generate next `u64` output.
+    ///
+    /// `u64` is the native output of the generator. This function advances the
+    /// RNG step counter by one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rand_core::RngCore;
+    /// use rand_mt::Mt19937GenRand64;
+    ///
+    /// let mut rng = Mt19937GenRand64::new_unseeded();
+    /// # fn example<T: RngCore>(mut rng: T) {
+    /// assert_ne!(rng.next_u64(), rng.next_u64());
+    /// # }
+    /// # example(rng);
+    /// ```
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        Self::next_u64(self)
+    }
+
+    /// Generate next `u32` output.
+    ///
+    /// This function is implemented by generating one `u64`s from the RNG and
+    /// shifting + masking them into a `u32` output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rand_core::RngCore;
+    /// use rand_mt::Mt19937GenRand64;
+    ///
+    /// let mut rng = Mt19937GenRand64::new_unseeded();
+    /// # fn example<T: RngCore>(mut rng: T) {
+    /// assert_ne!(rng.next_u32(), rng.next_u32());
+    /// # }
+    /// # example(rng);
+    /// ```
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        Self::next_u32(self)
+    }
+
+    /// Fill a buffer with bytes generated from the RNG.
+    ///
+    /// This method generates random `u64`s (the native output unit of the RNG)
+    /// until `dest` is filled.
+    ///
+    /// This method may discard some output bits if `dest.len()` is not a
+    /// multiple of 8.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rand_core::RngCore;
+    /// use rand_mt::Mt19937GenRand64;
+    ///
+    /// let mut rng = Mt19937GenRand64::new_unseeded();
+    /// # fn example<T: RngCore>(mut rng: T) {
+    /// let mut buf = [0; 32];
+    /// rng.fill_bytes(&mut buf);
+    /// assert_ne!([0; 32], buf);
+    /// let mut buf = [0; 31];
+    /// rng.fill_bytes(&mut buf);
+    /// assert_ne!([0; 31], buf);
+    /// # }
+    /// # example(rng);
+    /// ```
+    #[inline]
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        Self::fill_bytes(self, dest)
+    }
+
+    /// Fill a buffer with bytes generated from the RNG.
+    ///
+    /// This method generates random `u64`s (the native output unit of the RNG)
+    /// until `dest` is filled.
+    ///
+    /// This method may discard some output bits if `dest.len()` is not a
+    /// multiple of 8.
+    ///
+    /// `try_fill_bytes` is implemented with [`fill_bytes`](RngCore::fill_bytes)
+    /// and is infallible.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rand_core::RngCore;
+    /// use rand_mt::Mt19937GenRand64;
+    ///
+    /// let mut rng = Mt19937GenRand64::new_unseeded();
+    /// # fn example<T: RngCore>(mut rng: T) -> Result<(), rand_core::Error> {
+    /// let mut buf = [0; 32];
+    /// rng.try_fill_bytes(&mut buf)?;
+    /// assert_ne!([0; 32], buf);
+    /// let mut buf = [0; 31];
+    /// rng.try_fill_bytes(&mut buf)?;
+    /// assert_ne!([0; 31], buf);
+    /// # Ok(())
+    /// # }
+    /// # example(rng).unwrap()
+    /// ```
+    #[inline]
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        Self::fill_bytes(self, dest);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::num::Wrapping;
+    use rand_core::{RngCore, SeedableRng};
+
+    use super::Mt19937GenRand64;
+    use crate::vectors::mt64::{STATE_SEEDED_BY_U64, TEST_OUTPUT};
+
+    #[test]
+    fn seeded_state_from_u64_seed() {
+        let mt = Mt19937GenRand64::new(0x0123_4567_89ab_cdef_u64);
+        let mt_from_seed = Mt19937GenRand64::from_seed(0x0123_4567_89ab_cdef_u64.to_le_bytes());
+        assert_eq!(mt.state, mt_from_seed.state);
+        for (&Wrapping(x), &y) in mt.state.iter().zip(STATE_SEEDED_BY_U64.iter()) {
+            assert_eq!(x, y);
+        }
+        for (&Wrapping(x), &y) in mt_from_seed.state.iter().zip(STATE_SEEDED_BY_U64.iter()) {
+            assert_eq!(x, y);
+        }
+    }
+
+    #[test]
+    fn output_from_u64_slice_key() {
+        let key = [0x12345_u64, 0x23456_u64, 0x34567_u64, 0x45678_u64];
+        let mut mt = Mt19937GenRand64::new_with_key(key.iter().copied());
+        for &x in TEST_OUTPUT.iter() {
+            assert_eq!(x, RngCore::next_u64(&mut mt));
+        }
+    }
+}


### PR DESCRIPTION
This PR makes `rand_core` optional for using `rand_mt`:

- The API of `rand_core` (except for `try_fill_bytes`) is made available as inherent methods on `Mt` and `Mt64`.
- Implementations of `RngCore` and `SeedableRng` require the on by default `rand-traits` Cargo feature.
- Implement `RngCore` by delegating to inherent methods to avoid code duplication and binary bloat.
- `rand_core` is built with `default-features = false`.
- Document Cargo features in README and crate-level documentation.
- Make the `SeedableRng` trait impl available without `rand-traits` feature by adding `impl From<[u8; 4]> for Mt19937GenRand32` and `impl From<[u8; 8]> for Mt19937GenRand364`.
- Add tests specific to `rand-traits` trait impls that go through `RngCore` and `SeedableRng`.

This PR makes some quality improvements since much of the code had to be touched again:

- Add `impl From<u32> for Mt19937GenRand32` and `impl From<u64> for Mt19937GenRand64` that are wrappers around `new`.
- Add missing `#[inline]` annotations.
- Move `fill_next_state` to be a private free function for `Mt` and `Mt64`.
- Refactor tests for readability.