### PR TITLE
Add package.metadata.docs.rs configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,8 @@ rand_core = { version = "0.5", default-features = false, optional = true }
 quickcheck = { version = "0.9", default-features = false }
 quickcheck_macros = "0.9"
 version-sync = "0.9"
+
+[package.metadata.docs.rs]
+# This sets the default target to `x86_64-unknown-linux-gnu` and only builds
+# that target. `rand_mt` has the same API and code on all targets.
+targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Limit docs.rs builds to `x86_64-unknown-linux-gnu` since `rand_mt` does not use platform-specific cfg feature gates.