### PR TITLE
Remove quickcheck dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,7 @@ std = []
 rand_core = { version = "0.5", default-features = false, optional = true }
 
 [dev-dependencies]
-quickcheck = { version = "0.9", default-features = false }
-quickcheck_macros = "0.9"
+getrandom = { version = "0.2", default-features = false }
 version-sync = "0.9"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Remove `quickcheck` dependency for `recover`, `temper`, and `untemper`
tests. Replace with loops and `getrandom::getrandom` for generating
integers to test.

This removes all dependencies that pull in `rand` and `rand_core`, which
will make updating `rand` in this crate easier moving forward.

See https://github.com/BurntSushi/quickcheck/pull/264#issuecomment-751478991.