### PR TITLE
Prepare for v4.0.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_mt"
-version = "3.0.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "4.0.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["David Creswick <dcrewi@gyrae.net>", "Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rand_mt = "3"
+rand_mt = "4"
 ```
 
 Then create a RNG like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@
 //! [`rand_core`]: https://crates.io/crates/rand_core
 //! [`std::error::error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 
-#![doc(html_root_url = "https://docs.rs/rand_mt/3.0.0")]
+#![doc(html_root_url = "https://docs.rs/rand_mt/4.0.0")]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 // Ensure code blocks in README.md compile


### PR DESCRIPTION
Release `rand_mt` 4.0.0. This release is a new major version and contains breaking changes.

[`rand_mt` is published on crates.io](https://crates.io/crates/rand_mt/4.0.0).

This release contains enhancements and breaking changes:

- [BREAKING] `rand_mt` requires at least Rust `1.47.0`. #49
- [BREAKING] Update `rand_core` dependency to `0.6.0`. #46
- [BREAKING] `rand_core` is an optional dependency. Activate implementations of `rand_core::RngCore` by enabling the **rand-traits** feature. #50
- Implement the core `Mt` and `Mt64` APIs as methods on the types' inherent impl block. #50
- Derive `Hash`, `PartialEq`, `Eq`, `PartialOrd`, `Ord` using built-in derive macros. #49
- Update `version-sync` dev dependency to `0.9`. #28
- Remove `doc-comment` dev dependency and replace with a small, inlined macro. #35
- Remove `quickcheck` and `quickcheck_macros` dev dependencies; use `getrandom` instead. #53

This release contains improvements to documentation, testing, and release packaging.