### PR TITLE
Require version-sync at least 0.9.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rand_core = { version = "0.6", default-features = false, optional = true }
 
 [dev-dependencies]
 getrandom = { version = "0.2", default-features = false }
-version-sync = "0.9"
+version-sync = "0.9, >= 0.9.2"
 
 [package.metadata.docs.rs]
 # This sets the default target to `x86_64-unknown-linux-gnu` and only builds

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ rand_core = { version = "0.6", default-features = false, optional = true }
 
 [dev-dependencies]
 getrandom = { version = "0.2", default-features = false }
+# Check that crate versions are properly updated in documentation and code when
+# bumping the version.
 version-sync = "0.9, >= 0.9.2"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
This fixes some warnings on current nightly related to panic formatting.