### PR TITLE
Release v4.0.1 with updated rand_core version constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_mt"
-version = "4.0.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "4.0.1" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["David Creswick <dcrewi@gyrae.net>", "Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@
 //! [`rand_core`]: https://crates.io/crates/rand_core
 //! [`std::error::error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 
-#![doc(html_root_url = "https://docs.rs/rand_mt/4.0.0")]
+#![doc(html_root_url = "https://docs.rs/rand_mt/4.0.1")]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 // Ensure code blocks in README.md compile


### PR DESCRIPTION
To ensure that [RUSTSEC-2021-0023](https://rustsec.org/advisories/RUSTSEC-2021-0023.html) is addressed.

After this release, I plan to yank v4.0.0.