### PR TITLE
Fix devtools to work on Windows

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,10 +8,11 @@ AllCops:
     - "**/node_modules/**/*"
     - "**/target/**/*"
     - "**/vendor/**/*"
+Layout/EndOfLine:
+  EnforcedStyle: lf
 Layout/LineLength:
   Enabled: true
   Exclude:
-    - "scripts/gen_case_lookups.rb"
     - "**/Rakefile"
 Metrics:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -53,7 +53,7 @@ namespace :format do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    sh "npx prettier --write '**/*'"
+    sh 'npx prettier --write "**/*"'
   end
 end
 
@@ -68,7 +68,7 @@ namespace :fmt do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    sh "npx prettier --write '**/*'"
+    sh 'npx prettier --write "**/*"'
   end
 end
 


### PR DESCRIPTION
- Force unix-style line endings on Windows with RuboCop.
- Fix prettier glob quoting to work  on Windows in `package.json` run script and `Rakefile`.