### PR TITLE
Update Audit GitHub Actions workflow

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -10,8 +10,42 @@ name: Audit
   schedule:
     - cron: "0 0 * * TUE"
 jobs:
+  js:
+    name: Audit JS Dependencies
+    if: false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Nodejs toolchain
+        run: npm ci
+
+      - name: npm audit
+        run: npm audit
+
+  ruby:
+    name: Audit Ruby Dependencies
+    if: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Ruby toolchain
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ".ruby-version"
+          bundler-cache: true
+
+      - name: bundler-audit
+        run: bundle exec bundle-audit check --update
+
   rust:
     name: Audit Rust Dependencies
+    if: true
     runs-on: ubuntu-latest
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,7 @@ tasks by running:
 ```console
 $ bundle exec rake --tasks
 rake build                        # Build Rust workspace
+rake bundle:audit                 # Checks the Gemfile.lock for insecure dependencies
 rake doc                          # Generate Rust API documentation
 rake doc:open                     # Generate Rust API documentation and open it in a web browser
 rake fmt                          # Format sources

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source 'https://rubygems.org'
 
+gem 'bundler-audit', '~> 0.8', require: false
 gem 'rake', '>= 12.3.3', require: false
 gem 'rubocop', '~> 1.18', require: false
 gem 'rubocop-rake', '~> 0.6', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    bundler-audit (0.8.0)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 1.0)
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -23,15 +26,17 @@ GEM
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
     ruby-progressbar (1.11.0)
+    thor (1.1.0)
     unicode-display_width (2.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  bundler-audit (~> 0.8)
   rake (>= 12.3.3)
   rubocop (~> 1.18)
   rubocop-rake (~> 0.6)
 
 BUNDLED WITH
-   2.0.2
+   2.2.22

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 
 require 'open-uri'
 require 'shellwords'
+require 'bundler/audit/task'
 require 'rubocop/rake_task'
 
 task default: %i[format lint]
@@ -90,6 +91,8 @@ desc 'Run rand_mt unit tests'
 task :test do
   sh 'cargo test --workspace'
 end
+
+Bundler::Audit::Task.new
 
 namespace :release do
   link_check_files = FileList.new('**/*.md') do |f|


### PR DESCRIPTION
Managed by Terraform.

The cargo-deny version is 0.9.1.

Pushed commit cb41c9f7ec6ee4337f1e60b7998c8a910678327b.
