### PR TITLE
Remove touch command for entrypoints which was made unnecessary in Rust 1.52.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,9 +20,6 @@ namespace :lint do
 
   desc 'Lint Rust sources with Clippy restriction pass (unenforced lints)'
   task :'clippy:restriction' do
-    FileList['**/{build,lib,main}.rs'].each do |root|
-      FileUtils.touch(root)
-    end
     lints = [
       'clippy::dbg_macro',
       'clippy::get_unwrap',


### PR DESCRIPTION
Missed a Rake task in #98.