### PR TITLE
Remove allow pragmas for `clippy::missing_panics_docs`

### DIFF
--- a/src/mt.rs
+++ b/src/mt.rs
@@ -268,7 +268,6 @@ impl Mt19937GenRand32 {
     /// assert_ne!(mt.next_u32(), mt.next_u32());
     /// ```
     #[inline]
-    #[allow(clippy::missing_panics_doc)]
     pub fn next_u32(&mut self) -> u32 {
         // Failing this check indicates that, somehow, the structure
         // was not initialized.

--- a/src/mt64.rs
+++ b/src/mt64.rs
@@ -233,7 +233,6 @@ impl Mt19937GenRand64 {
     /// assert_ne!(mt.next_u64(), mt.next_u64());
     /// ```
     #[inline]
-    #[allow(clippy::missing_panics_doc)]
     pub fn next_u64(&mut self) -> u64 {
         // Failing this check indicates that, somehow, the structure
         // was not initialized.


### PR DESCRIPTION
This false positive was addressed in rust-lang/rust-clippy#6996.

This rolls back the `allow` introduced in https://github.com/artichoke/rand_mt/pull/66.