### PR TITLE
Add GitHub Actions councurrency limits to workflows that `git push`

### DIFF
--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -9,6 +9,8 @@ name: Documentation
       - trunk
   schedule:
     - cron: "0 0 * * TUE"
+concurrency:
+  group: docs-${{ github.head_ref }}
 jobs:
   rustdoc:
     name: Build Rust API docs


### PR DESCRIPTION
Occasionally when multiple PRs are merged to trunk quickly, the rustdoc
workflow fails due to a race between generating a new commit to push and
another workflow instance completing a push.

Limit workflow concurrency to one concurrent run per branch to ensure
pushes to trunk are processed serially.

https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/