### PR TITLE
Replaces hand-rolled loops in `fill_bytes` with `chunks_exact_mut`

### DIFF
--- a/src/mt.rs
+++ b/src/mt.rs
@@ -303,17 +303,19 @@ impl Mt19937GenRand32 {
     #[inline]
     pub fn fill_bytes(&mut self, dest: &mut [u8]) {
         const CHUNK: usize = size_of::<u32>();
-        let mut left = dest;
-        while left.len() >= CHUNK {
-            let (next, remainder) = left.split_at_mut(CHUNK);
-            left = remainder;
+        let mut left = dest.chunks_exact_mut(CHUNK);
+
+        for next in &mut left {
             let chunk: [u8; CHUNK] = self.next_u32().to_le_bytes();
             next.copy_from_slice(&chunk);
         }
-        let n = left.len();
+
+        let remainder = left.into_remainder();
+        let n = remainder.len();
+
         if n > 0 {
             let chunk: [u8; CHUNK] = self.next_u32().to_le_bytes();
-            left.copy_from_slice(&chunk[..n]);
+            remainder.copy_from_slice(&chunk[..n]);
         }
     }
 

--- a/src/mt.rs
+++ b/src/mt.rs
@@ -303,20 +303,20 @@ impl Mt19937GenRand32 {
     #[inline]
     pub fn fill_bytes(&mut self, dest: &mut [u8]) {
         const CHUNK: usize = size_of::<u32>();
-        let mut left = dest.chunks_exact_mut(CHUNK);
+        let mut dest_chunks = dest.chunks_exact_mut(CHUNK);
 
-        for next in &mut left {
+        for next in &mut dest_chunks {
             let chunk: [u8; CHUNK] = self.next_u32().to_le_bytes();
             next.copy_from_slice(&chunk);
         }
 
-        let remainder = left.into_remainder();
-        let n = remainder.len();
-
-        if n > 0 {
-            let chunk: [u8; CHUNK] = self.next_u32().to_le_bytes();
-            remainder.copy_from_slice(&chunk[..n]);
-        }
+        dest_chunks
+            .into_remainder()
+            .iter_mut()
+            .zip(self.next_u32().to_le_bytes().iter())
+            .for_each(|(cell, &byte)| {
+                *cell = byte;
+            });
     }
 
     /// Attempt to recover the internal state of a Mersenne Twister using the

--- a/src/mt64.rs
+++ b/src/mt64.rs
@@ -286,17 +286,19 @@ impl Mt19937GenRand64 {
     #[inline]
     pub fn fill_bytes(&mut self, dest: &mut [u8]) {
         const CHUNK: usize = size_of::<u64>();
-        let mut left = dest;
-        while left.len() >= CHUNK {
-            let (next, remainder) = left.split_at_mut(CHUNK);
-            left = remainder;
+        let mut left = dest.chunks_exact_mut(CHUNK);
+
+        for next in &mut left {
             let chunk: [u8; CHUNK] = self.next_u64().to_le_bytes();
             next.copy_from_slice(&chunk);
         }
-        let n = left.len();
+
+        let remainder = left.into_remainder();
+        let n = remainder.len();
+
         if n > 0 {
             let chunk: [u8; CHUNK] = self.next_u64().to_le_bytes();
-            left.copy_from_slice(&chunk[..n]);
+            remainder.copy_from_slice(&chunk[..n]);
         }
     }
 

--- a/src/mt64.rs
+++ b/src/mt64.rs
@@ -286,20 +286,20 @@ impl Mt19937GenRand64 {
     #[inline]
     pub fn fill_bytes(&mut self, dest: &mut [u8]) {
         const CHUNK: usize = size_of::<u64>();
-        let mut left = dest.chunks_exact_mut(CHUNK);
+        let mut dest_chunks = dest.chunks_exact_mut(CHUNK);
 
-        for next in &mut left {
+        for next in &mut dest_chunks {
             let chunk: [u8; CHUNK] = self.next_u64().to_le_bytes();
             next.copy_from_slice(&chunk);
         }
 
-        let remainder = left.into_remainder();
-        let n = remainder.len();
-
-        if n > 0 {
-            let chunk: [u8; CHUNK] = self.next_u64().to_le_bytes();
-            remainder.copy_from_slice(&chunk[..n]);
-        }
+        dest_chunks
+            .into_remainder()
+            .iter_mut()
+            .zip(self.next_u64().to_le_bytes().iter())
+            .for_each(|(cell, &byte)| {
+                *cell = byte;
+            });
     }
 
     /// Attempt to recover the internal state of a Mersenne Twister using the


### PR DESCRIPTION
Whew, as a Rubyist it took me a while to figure out what all the bits and bytes were doing, but I think this should do it. Please let me know if this PR requires anything else. 

Closes #114 