### PR TITLE
Release v4.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_mt"
-version = "4.0.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "4.1.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["David Creswick <dcrewi@gyrae.net>", "Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rand_mt = "4"
+rand_mt = "4.1"
 ```
 
 Then create a RNG like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@
 //! [`rand_core`]: https://crates.io/crates/rand_core
 //! [`std::error::error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 
-#![doc(html_root_url = "https://docs.rs/rand_mt/4.0.1")]
+#![doc(html_root_url = "https://docs.rs/rand_mt/4.1.0")]
 #![no_std]
 
 // Ensure code blocks in README.md compile


### PR DESCRIPTION
## Release Notes

Release `rand_mt` 4.1.0.

[`rand_mt` is published on crates.io](https://crates.io/crates/rand_mt/4.1.0).

## Improvements

This release contains security updates and internal refactorings:

- Update dev-dependencies and remove some transitive dependencies. https://github.com/artichoke/rand_mt/pull/112
- Improve performance of `fill_bytes` functions. https://github.com/artichoke/rand_mt/pull/116
- Resync the text of the Apache-2.0 license file. https://github.com/artichoke/rand_mt/pull/118
- Unconditionally make crate 'no_std' and explicitly link to `std` when the feature is enabled. https://github.com/artichoke/rand_mt/pull/119

This release contains improvements to documentation, testing, and release packaging.