### PR TITLE
Do not eagerly call `next_uNN` in `fill_bytes` with empty remainder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_mt"
-version = "4.1.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "4.1.1" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["David Creswick <dcrewi@gyrae.net>", "Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@
 //! [`rand_core`]: https://crates.io/crates/rand_core
 //! [`std::error::error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 
-#![doc(html_root_url = "https://docs.rs/rand_mt/4.1.0")]
+#![doc(html_root_url = "https://docs.rs/rand_mt/4.1.1")]
 #![no_std]
 
 // Ensure code blocks in README.md compile

--- a/src/mt.rs
+++ b/src/mt.rs
@@ -310,8 +310,11 @@ impl Mt19937GenRand32 {
             next.copy_from_slice(&chunk);
         }
 
-        dest_chunks
-            .into_remainder()
+        let remainder = dest_chunks.into_remainder();
+        if remainder.is_empty() {
+            return;
+        }
+        remainder
             .iter_mut()
             .zip(self.next_u32().to_le_bytes().iter())
             .for_each(|(cell, &byte)| {

--- a/src/mt64.rs
+++ b/src/mt64.rs
@@ -293,8 +293,11 @@ impl Mt19937GenRand64 {
             next.copy_from_slice(&chunk);
         }
 
-        dest_chunks
-            .into_remainder()
+        let remainder = dest_chunks.into_remainder();
+        if remainder.is_empty() {
+            return;
+        }
+        remainder
             .iter_mut()
             .zip(self.next_u64().to_le_bytes().iter())
             .for_each(|(cell, &byte)| {

--- a/tests/ruby_reproducibility.rs
+++ b/tests/ruby_reproducibility.rs
@@ -1,0 +1,32 @@
+use rand_mt::Mt;
+
+// ```ruby
+// # Should double check this is official spec
+// it "returns the same numeric output for a given seed across all implementations and platforms" do
+//   rnd = Random.new(33)
+//   rnd.bytes(2).should == "\x14\\"
+//   rnd.bytes(1000) # skip some
+//   rnd.bytes(2).should == "\xA1p"
+// end
+//
+// it "returns the same numeric output for a given huge seed across all implementations and platforms" do
+//   rnd = Random.new(bignum_value ** 4)
+//   rnd.bytes(2).should == "_\x91"
+//   rnd.bytes(1000) # skip some
+//   rnd.bytes(2).should == "\x17\x12"
+// end
+// ```
+#[test]
+fn spec_bytes() {
+    let mut rng = Mt::new(33);
+    let mut buf = [0; 2];
+    rng.fill_bytes(&mut buf);
+    assert_eq!(buf[..], b"\x14\\"[..]);
+
+    let mut skip = [0; 1000];
+    rng.fill_bytes(&mut skip);
+
+    let mut buf = [0; 2];
+    rng.fill_bytes(&mut buf);
+    assert_eq!(buf[..], b"\xA1p"[..]);
+}


### PR DESCRIPTION
Fix a bug where random numbers are consumed from the Mersenne Twister
even when they will never be used because the remainder from the chunks
iterator in `fill_bytes` is non-empty.

This regression was introduced in:

- https://github.com/artichoke/rand_mt/pull/116

Add a basic smoke check for reproducibility with MRI's RNG pulled from
`spinoso-random` in artichoke/artichoke.

Prepare to release this change as v4.1.1 and yank v4.1.0.