### PR TITLE
Release v4.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_mt"
-version = "4.1.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "4.1.2" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["David Creswick <dcrewi@gyrae.net>", "Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rand_mt = "4.1.1"
+rand_mt = "4.1.2"
 ```
 
 Then create a RNG like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@
 //! [`rand_core`]: https://crates.io/crates/rand_core
 //! [`std::error::error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 
-#![doc(html_root_url = "https://docs.rs/rand_mt/4.1.1")]
+#![doc(html_root_url = "https://docs.rs/rand_mt/4.1.2")]
 #![no_std]
 
 // Ensure code blocks in README.md compile


### PR DESCRIPTION
Release `rand_mt` 4.1.2.

[`rand_mt` is published on crates.io](https://crates.io/crates/rand_mt/4.1.2).

## Improvements

This release contains testing and packaging improvements:

- Update Cargo.toml manifest version and docs.rs metadata. https://github.com/artichoke/rand_mt/pull/125
- Use precise crate version in Cargo.toml snippet in README. https://github.com/artichoke/rand_mt/pull/131
- Add reproducibility test for `Mt::new_with_key`. https://github.com/artichoke/rand_mt/pull/145
- Fix clippy violations for `clippy::assertions_on_result_states`. https://github.com/artichoke/rand_mt/pull/151

## Bug Fixes

- Add tests for `fmt::Debug` impls on MT structs. https://github.com/artichoke/rand_mt/pull/152