### PR TITLE
Add additional tests and doc examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_mt"
-version = "4.1.2" # remember to set `html_root_url` in `src/lib.rs`.
+version = "4.1.3" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["David Creswick <dcrewi@gyrae.net>", "Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rand_mt = "4.1.2"
+rand_mt = "4.1.3"
 ```
 
 Then create a RNG like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@
 //! [`rand_core`]: https://crates.io/crates/rand_core
 //! [`std::error::error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 
-#![doc(html_root_url = "https://docs.rs/rand_mt/4.1.2")]
+#![doc(html_root_url = "https://docs.rs/rand_mt/4.1.3")]
 #![no_std]
 
 // Ensure code blocks in README.md compile
@@ -166,3 +166,28 @@ impl fmt::Display for RecoverRngError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for RecoverRngError {}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "std")]
+    use super::RecoverRngError;
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn error_display_is_not_empty() {
+        use core::fmt::Write as _;
+        use std::string::String;
+
+        let test_cases = [
+            RecoverRngError::TooFewSamples(0),
+            RecoverRngError::TooFewSamples(124),
+            RecoverRngError::TooManySamples(0),
+            RecoverRngError::TooManySamples(987),
+        ];
+        for tc in test_cases {
+            let mut buf = String::new();
+            write!(&mut buf, "{}", tc).unwrap();
+            assert!(!buf.is_empty());
+        }
+    }
+}

--- a/src/mt.rs
+++ b/src/mt.rs
@@ -107,6 +107,23 @@ impl From<u32> for Mt19937GenRand32 {
     ///
     /// This function is equivalent to [`new`].
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use rand_mt::Mt19937GenRand32;
+    /// // Default MT seed
+    /// let seed = 5489_u32;
+    /// let mt1 = Mt19937GenRand32::from(seed);
+    /// let mt2 = Mt19937GenRand32::new(seed);
+    /// assert_eq!(mt1, mt2);
+    ///
+    /// // Non-default MT seed
+    /// let seed = 9927_u32;
+    /// let mt1 = Mt19937GenRand32::from(seed);
+    /// let mt2 = Mt19937GenRand32::new(seed);
+    /// assert_eq!(mt1, mt2);
+    /// ```
+    ///
     /// [`new`]: Self::new
     #[inline]
     fn from(seed: u32) -> Self {

--- a/src/mt64.rs
+++ b/src/mt64.rs
@@ -91,6 +91,23 @@ impl From<u64> for Mt19937GenRand64 {
     ///
     /// This function is equivalent to [`new`].
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use rand_mt::Mt19937GenRand64;
+    /// // Default MT seed
+    /// let seed = 5489_u64;
+    /// let mt1 = Mt19937GenRand64::from(seed);
+    /// let mt2 = Mt19937GenRand64::new(seed);
+    /// assert_eq!(mt1, mt2);
+    ///
+    /// // Non-default MT seed
+    /// let seed = 9927_u64;
+    /// let mt1 = Mt19937GenRand64::from(seed);
+    /// let mt2 = Mt19937GenRand64::new(seed);
+    /// assert_eq!(mt1, mt2);
+    /// ```
+    ///
     /// [`new`]: Self::new
     #[inline]
     fn from(seed: u64) -> Self {


### PR DESCRIPTION
Add additional tests and doctests which for previously uncovered functions as found by `cargo-mutants`.

- Add tests that `impl fmt::Display for RecoverRngError` does not error and results in non-empty output.
- Add examples and tests that `impl From<u32> for Mt19937GenRand32` behaves the same as `Mt19937GenRand32::new`.
- Add examples and tests that `impl From<u64> for Mt19937GenRand64` behaves the same as `Mt19937GenRand64::new`.

Because there are documentation improvements, prepare for v4.1.3 release.