### PR TITLE
Add license notices in source code

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,3 +1,14 @@
+// benches/benchmarks.rs
+//
+// Copyright (c) 2015,2017 rust-mersenne-twister developers
+// Copyright (c) 2020 Ryan Lopopolo <rjl@hyperbo.la>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 #![feature(test)]
 extern crate test;
 

--- a/src/mt.rs
+++ b/src/mt.rs
@@ -1,4 +1,4 @@
-// src/mt19937.rs
+// src/mt.rs
 //
 // Copyright (c) 2015,2017 rust-mersenne-twister developers
 // Copyright (c) 2020 Ryan Lopopolo <rjl@hyperbo.la>

--- a/src/mt/rand.rs
+++ b/src/mt/rand.rs
@@ -1,3 +1,14 @@
+// src/mt/rand.rs
+//
+// Copyright (c) 2015,2017 rust-mersenne-twister developers
+// Copyright (c) 2020 Ryan Lopopolo <rjl@hyperbo.la>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 use rand_core::{Error, RngCore, SeedableRng};
 
 use super::Mt19937GenRand32;

--- a/src/mt64.rs
+++ b/src/mt64.rs
@@ -1,4 +1,4 @@
-// src/mt19937_64.rs
+// src/mt64.rs
 //
 // Copyright (c) 2015,2017 rust-mersenne-twister developers
 // Copyright (c) 2020 Ryan Lopopolo <rjl@hyperbo.la>

--- a/src/mt64/rand.rs
+++ b/src/mt64/rand.rs
@@ -1,3 +1,14 @@
+// src/mt64/rand.rs
+//
+// Copyright (c) 2015,2017 rust-mersenne-twister developers
+// Copyright (c) 2020 Ryan Lopopolo <rjl@hyperbo.la>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 use rand_core::{Error, RngCore, SeedableRng};
 
 use super::Mt19937GenRand64;

--- a/src/vectors.rs
+++ b/src/vectors.rs
@@ -1,4 +1,4 @@
-// src/vectors/mod.rs
+// src/vectors.rs
 //
 // Copyright (c) 2015,2017 rust-mersenne-twister developers
 // Copyright (c) 2020 Ryan Lopopolo <rjl@hyperbo.la>

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -1,2 +1,13 @@
+// src/vectors/mod.rs
+//
+// Copyright (c) 2015,2017 rust-mersenne-twister developers
+// Copyright (c) 2020 Ryan Lopopolo <rjl@hyperbo.la>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 pub mod mt;
 pub mod mt64;

--- a/src/vectors/mt.rs
+++ b/src/vectors/mt.rs
@@ -1,3 +1,14 @@
+// src/vectors/mt.rs
+//
+// Copyright (c) 2015,2017 rust-mersenne-twister developers
+// Copyright (c) 2020 Ryan Lopopolo <rjl@hyperbo.la>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 const N: usize = 624;
 
 pub static STATE_SEEDED_BY_U32: [u32; N] = [

--- a/src/vectors/mt64.rs
+++ b/src/vectors/mt64.rs
@@ -1,3 +1,14 @@
+// src/vectors/mt64.rs
+//
+// Copyright (c) 2015,2017 rust-mersenne-twister developers
+// Copyright (c) 2020 Ryan Lopopolo <rjl@hyperbo.la>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 const NN: usize = 312;
 
 pub static STATE_SEEDED_BY_U64: [u64; NN] = [

--- a/tests/ruby_reproducibility.rs
+++ b/tests/ruby_reproducibility.rs
@@ -1,3 +1,14 @@
+// tests/ruby_reproducibility.rs
+//
+// Copyright (c) 2015,2017 rust-mersenne-twister developers
+// Copyright (c) 2020 Ryan Lopopolo <rjl@hyperbo.la>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 use rand_mt::Mt;
 
 // # ruby/spec Random

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -1,3 +1,14 @@
+// tests/version_numbers.rs
+//
+// Copyright (c) 2015,2017 rust-mersenne-twister developers
+// Copyright (c) 2020 Ryan Lopopolo <rjl@hyperbo.la>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 #[test]
 fn test_readme_deps() {
     version_sync::assert_markdown_deps_updated!("README.md");


### PR DESCRIPTION
Per the Apache 2.0 License, a boilerplate notice must be included in all
source files to apply the license to this work:

```
   APPENDIX: How to apply the Apache License to your work.

      To apply the Apache License to your work, attach the following
      boilerplate notice, with the fields enclosed by brackets "[]"
      replaced with your own identifying information. (Don't include
      the brackets!)  The text should be enclosed in the appropriate
      comment syntax for the file format. We also recommend that a
      file or class name and description of purpose be included on the
      same "printed page" as the copyright notice for easier
      identification within third-party archives.

   Copyright [yyyy] [name of copyright owner]

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
```

Several of the Rust sources in `src` have such a notice, which
communicates the dual license of this crate as either Apache 2.0 OR MIT.

This commit fixes up the file paths referred to in these comments and
adds notice to source files that do not have one.