### PR TITLE
Prepare for v4.2.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_mt"
-version = "4.1.3" # remember to set `html_root_url` in `src/lib.rs`.
+version = "4.2.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["David Creswick <dcrewi@gyrae.net>", "Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rand_mt = "4.1.3"
+rand_mt = "4.2.0"
 ```
 
 Then create a RNG like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@
 //! [`rand_core`]: https://crates.io/crates/rand_core
 //! [`std::error::error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 
-#![doc(html_root_url = "https://docs.rs/rand_mt/4.1.3")]
+#![doc(html_root_url = "https://docs.rs/rand_mt/4.2.0")]
 #![no_std]
 
 // Ensure code blocks in README.md compile


### PR DESCRIPTION
Release `rand_mt` 4.2.0.

[`rand_mt` is published on crates.io](https://crates.io/crates/rand_mt/4.2.0).

## Improvements

This release contains packaging improvements:

- Properly structure source files to provide the Apache-2.0 boilerplate notice. https://github.com/artichoke/rand_mt/pull/157