### PR TITLE
Fix `clippy::let_underscore_untyped` lint violations on latest nightly

### DIFF
--- a/src/mt.rs
+++ b/src/mt.rs
@@ -529,7 +529,7 @@ mod tests {
 
     #[test]
     fn seed_with_empty_iter_returns() {
-        let _ = Mt19937GenRand32::new_with_key(iter::empty());
+        let _rng = Mt19937GenRand32::new_with_key(iter::empty());
     }
 
     #[test]

--- a/src/mt64.rs
+++ b/src/mt64.rs
@@ -510,7 +510,7 @@ mod tests {
 
     #[test]
     fn seed_with_empty_iter_returns() {
-        let _ = Mt19937GenRand64::new_with_key(core::iter::empty());
+        let _rng = Mt19937GenRand64::new_with_key(core::iter::empty());
     }
 
     #[test]


### PR DESCRIPTION
```
error: non-binding `let` without a type annotation
   --> src/mt.rs:532:9
    |
532 |         let _ = Mt19937GenRand32::new_with_key(iter::empty());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider adding a type annotation or removing the `let` keyword
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_underscore_untyped
note: the lint level is defined here
   --> src/lib.rs:13:9
    |
13  | #![deny(clippy::pedantic)]
    |         ^^^^^^^^^^^^^^^^
    = note: `#[deny(clippy::let_underscore_untyped)]` implied by `#[deny(clippy::pedantic)]`

error: non-binding `let` without a type annotation
   --> src/mt64.rs:513:9
    |
513 |         let _ = Mt19937GenRand64::new_with_key(core::iter::empty());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider adding a type annotation or removing the `let` keyword
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_underscore_untyped

error: could not compile `rand_mt` due to 2 previous errors
```