### PR TITLE
chore: Update `.github/workflows/code-coverage.yaml` in `artichoke/ra…

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -17,6 +17,7 @@ jobs:
     env:
       RUST_BACKTRACE: 1
       CARGO_NET_GIT_FETCH_WITH_CLI: true
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.5.2
@@ -46,7 +47,10 @@ jobs:
         env:
           LLVM_PROFILE_FILE: "rand_mt-%m-%p.profraw"
           RUSTFLAGS: "-C instrument-coverage"
-          # Unstable feature: https://github.com/rust-lang/rust/issues/56925
+          # Unstable feature: `--persist-doctests`: persist doctest executables after running
+          # https://rustwiki.org/en/rustdoc/unstable-features.html#--persist-doctests-persist-doctest-executables-after-running
+          #
+          # Used to allow grcov to use these sources to generate coverage metrics.
           RUSTDOCFLAGS: "-C instrument-coverage -Z unstable-options --persist-doctests target/debug/doctests"
         run: cargo test
 
@@ -77,26 +81,43 @@ jobs:
           aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/rand_mt/ --delete --sse AES256 --include '*' --exclude '*.svg' --exclude '*.html' --exclude '*.json'
 
       - name: Check missed lines
+        shell: python
         run: |
-          curl -s https://codecov.artichokeruby.org/rand_mt/coverage.json | python -c '\
-          import sys, json; \
-          \
-          trunk_coverage = json.loads(sys.stdin.read()); \
-          print("On trunk: "); \
-          print("coveragePercent =", trunk_coverage["coveragePercent"]); \
-          print("linesCovered =", trunk_coverage["linesCovered"]); \
-          print("linesMissed =", trunk_coverage["linesMissed"]); \
-          print("linesTotal =", trunk_coverage["linesTotal"]); \
-          print(""); \
-          \
-          branch_coverage = json.load(open("target/coverage/coverage.json"))
-          print("On PR branch: "); \
-          print("coveragePercent =", branch_coverage["coveragePercent"]); \
-          print("linesCovered =", branch_coverage["linesCovered"]); \
-          print("linesMissed =", branch_coverage["linesMissed"]); \
-          print("linesTotal =", branch_coverage["linesTotal"]); \
-          print(""); \
-          \
-          is_ok = branch_coverage["linesMissed"] <= trunk_coverage["linesMissed"]; \
-          exit(0) if is_ok else exit(1) \
-          '
+          import json
+          from urllib.request import urlopen
+
+          trunk_coverage_url = "https://codecov.artichokeruby.org/rand_mt/coverage.json"
+
+
+          def print_report(coverage, *, on=None):
+              if on is None:
+                  raise ValueError("must provide `on` kwarg")
+
+              print(f"On {on}:")
+              print("coveragePercent =", coverage["coveragePercent"])
+              print("linesCovered =", coverage["linesCovered"])
+              print("linesMissed =", coverage["linesMissed"])
+              print("linesTotal =", coverage["linesTotal"])
+              print("")
+
+
+          if "${{ github.ref_name }}" == "trunk":
+              # We don't need to compare trunk coverage to itself
+              exit(0)
+
+          with urlopen(trunk_coverage_url, data=None, timeout=3) as remote:
+              trunk_coverage = json.load(remote)
+
+          print_report(trunk_coverage, on="branch trunk")
+
+          with open("target/coverage/coverage.json") as local:
+              branch_coverage = json.load(local)
+
+          on = None
+          if "${{ github.event_name }}" == "pull_request":
+              on = "PR artichoke/rand_mt#${{ github.event.number }}"
+
+          print_report(branch_coverage, on=on)
+
+          is_ok = branch_coverage["linesMissed"] <= trunk_coverage["linesMissed"]
+          exit(0) if is_ok else exit(1)


### PR DESCRIPTION
…nd_mt`

Managed by Terraform.

## Contents

```
---
name: Code Coverage
"on":
  push:
    branches:
      - trunk
  pull_request:
    branches:
      - trunk
jobs:
  generate:
    name: Generate
    permissions:
      id-token: write
      contents: read
    runs-on: ubuntu-latest
    env:
      RUST_BACKTRACE: 1
      CARGO_NET_GIT_FETCH_WITH_CLI: true
      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
    steps:
      - name: Checkout repository
        uses: actions/checkout@v3.5.2

      - name: Install nightly Rust toolchain
        uses: artichoke/setup-rust/code-coverage@v1.9.0

      - name: Setup grcov
        run: |
          release_url="$(curl \
            --url https://api.github.com/repos/mozilla/grcov/releases \
            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
            --header 'content-type: application/json' \
            --silent \
            --fail \
            --retry 5 \
            | jq -r '.[0].assets
                     | map(select(.browser_download_url | test(".*x86_64-unknown-linux-musl.tar.bz2$")))
                     | .[0].browser_download_url'
          )"
          curl -sL "$release_url" | sudo tar xvj -C /usr/local/bin/

      - name: Show grcov version
        run: grcov --version

      - name: Generate coverage
        env:
          LLVM_PROFILE_FILE: "rand_mt-%m-%p.profraw"
          RUSTFLAGS: "-C instrument-coverage"
          # Unstable feature: `--persist-doctests`: persist doctest executables after running
          # https://rustwiki.org/en/rustdoc/unstable-features.html#--persist-doctests-persist-doctest-executables-after-running
          #
          # Used to allow grcov to use these sources to generate coverage metrics.
          RUSTDOCFLAGS: "-C instrument-coverage -Z unstable-options --persist-doctests target/debug/doctests"
        run: cargo test

      - name: Generate HTML report
        run: grcov rand_mt*.profraw --source-dir . --keep-only 'src/**/*.rs' --binary-path target/debug -t html --filter covered -o target/coverage

      - name: Generate detailed JSON report
        run: grcov rand_mt*.profraw --source-dir . --keep-only 'src/**/*.rs' --binary-path target/debug -t covdir --filter covered -o target/coverage/coverage.json

      - name: Configure AWS Credentials
        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
        if: github.ref == 'refs/heads/trunk'
        with:
          aws-region: us-west-2
          role-to-assume: arn:aws:iam::447522982029:role/gha-rand_mt-s3-backup-20220820215201568000000008
          role-session-name: GitHubActionsRustCodeCoverage@rand_mt

      - name: Show AWS caller identity
        if: github.ref == 'refs/heads/trunk'
        run: aws sts get-caller-identity

      - name: Upload archives to S3
        if: github.ref == 'refs/heads/trunk'
        run: |
          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/rand_mt/ --delete --sse AES256 --exclude '*' --include '*.svg' --content-type 'image/svg+xml'
          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/rand_mt/ --delete --sse AES256 --exclude '*' --include '*.html' --content-type 'text/html'
          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/rand_mt/ --delete --sse AES256 --exclude '*' --include '*.json' --content-type 'application/json'
          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/rand_mt/ --delete --sse AES256 --include '*' --exclude '*.svg' --exclude '*.html' --exclude '*.json'

      - name: Check missed lines
        shell: python
        run: |
          import json
          from urllib.request import urlopen

          trunk_coverage_url = "https://codecov.artichokeruby.org/rand_mt/coverage.json"


          def print_report(coverage, *, on=None):
              if on is None:
                  raise ValueError("must provide `on` kwarg")

              print(f"On {on}:")
              print("coveragePercent =", coverage["coveragePercent"])
              print("linesCovered =", coverage["linesCovered"])
              print("linesMissed =", coverage["linesMissed"])
              print("linesTotal =", coverage["linesTotal"])
              print("")


          if "${{ github.ref_name }}" == "trunk":
              # We don't need to compare trunk coverage to itself
              exit(0)

          with urlopen(trunk_coverage_url, data=None, timeout=3) as remote:
              trunk_coverage = json.load(remote)

          print_report(trunk_coverage, on="branch trunk")

          with open("target/coverage/coverage.json") as local:
              branch_coverage = json.load(local)

          on = None
          if "${{ github.event_name }}" == "pull_request":
              on = "PR artichoke/rand_mt#${{ github.event.number }}"

          print_report(branch_coverage, on=on)

          is_ok = branch_coverage["linesMissed"] <= trunk_coverage["linesMissed"]
          exit(0) if is_ok else exit(1)
```