### PR TITLE
Add no-std, no-alloc crates.io category metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_mt"
-version = "4.2.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "4.2.2" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["David Creswick <dcrewi@gyrae.net>", "Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/rand_mt"
 homepage = "https://github.com/artichoke/rand_mt"
 description = "Reference Mersenne Twister random number generators."
 keywords = ["random", "rand", "rng", "mt"]
-categories = ["algorithms", "no-std"]
+categories = ["algorithms", "no-std", "no-std::no-alloc"]
 include = ["src/**/*", "tests/**/*", "LICENSE-*", "README.md"]
 
 [features]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rand_mt = "4.2.1"
+rand_mt = "4.2.2"
 ```
 
 Then create a RNG like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@
 )]
 //!
 
-#![doc(html_root_url = "https://docs.rs/rand_mt/4.2.1")]
+#![doc(html_root_url = "https://docs.rs/rand_mt/4.2.2")]
 #![no_std]
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
Prepare for v4.2.2 release.