### PR TITLE
build!: bump rand_core to v0.10 and migrate rand traits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Install Rust toolchain
         uses: artichoke/setup-rust/build-and-test@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
         with:
-          toolchain: "1.81.0"
+          toolchain: "1.85.0"
 
       - name: Compile
         run: cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ authors = [
     "Ryan Lopopolo <rjl@hyperbo.la>",
 ]
 license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.81.0"
+edition = "2024"
+rust-version = "1.85.0"
 readme = "README.md"
 repository = "https://github.com/artichoke/rand_mt"
 documentation = "https://docs.rs/rand_mt"
@@ -22,7 +22,7 @@ default = ["rand-traits"]
 rand-traits = ["dep:rand_core"]
 
 [dependencies]
-rand_core = { version = "0.9.0", default-features = false, optional = true }
+rand_core = { version = "0.10.0", default-features = false, optional = true }
 
 [dev-dependencies]
 getrandom = { version = "0.3.1", default-features = false }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the [default PRNG in Ruby].
   http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
 [default prng in ruby]: https://ruby-doc.org/core-3.1.2/Random.html
 
-This crate optionally depends on [`rand_core`] and implements `RngCore` on the
+This crate optionally depends on [`rand_core`] and implements `Rng` on the
 RNGs in this crate.
 
 [`rand_core`]: https://crates.io/crates/rand_core
@@ -50,7 +50,7 @@ assert_ne!(rng.next_u64(), rng.next_u64());
 are enabled by default:
 
 - **rand-traits** - Enables a dependency on [`rand_core`]. Activating this
-  feature implements `RngCore` and `SeedableRng` on the RNGs in this crate.
+  feature implements `Rng` and `SeedableRng` on the RNGs in this crate.
 
 Mersenne Twister requires approximately 2.5 kilobytes of internal state. To make
 the RNGs implemented in this crate practical to embed in other structs, you may
@@ -58,7 +58,7 @@ wish to store the RNG in a `Box`.
 
 ### Minimum Supported Rust Version
 
-This crate requires at least Rust 1.81.0. This version can be bumped in minor
+This crate requires at least Rust 1.85.0. This version can be bumped in minor
 releases.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ the [default PRNG in Ruby].
   http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
 [default prng in ruby]: https://ruby-doc.org/core-3.1.2/Random.html
 
-This crate optionally depends on [`rand_core`] and implements `Rng` on the
-RNGs in this crate.
+This crate optionally depends on [`rand_core`] and implements `Rng` on the RNGs
+in this crate.
 
 [`rand_core`]: https://crates.io/crates/rand_core
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 //! that are enabled by default:
 //!
 //! - **rand-traits** - Enables a dependency on [`rand_core`]. Activating this
-//!   feature implements `RngCore` and `SeedableRng` on the RNGs in this crate.
+//!   feature implements `Rng` and `SeedableRng` on the RNGs in this crate.
 //!
 //! Mersenne Twister requires approximately 2.5 kilobytes of internal state. To
 //! make the RNGs implemented in this crate practical to embed in other structs,

--- a/src/mt.rs
+++ b/src/mt.rs
@@ -498,8 +498,8 @@ mod tests {
     use core::num::Wrapping;
 
     use super::{Mt, N};
-    use crate::vectors::mt::{STATE_SEEDED_BY_SLICE, STATE_SEEDED_BY_U32, TEST_OUTPUT};
     use crate::RecoverRngError;
+    use crate::vectors::mt::{STATE_SEEDED_BY_SLICE, STATE_SEEDED_BY_U32, TEST_OUTPUT};
 
     #[test]
     fn seeded_state_from_u32_seed() {

--- a/src/mt/rand.rs
+++ b/src/mt/rand.rs
@@ -9,7 +9,7 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use rand_core::{RngCore, SeedableRng};
+use rand_core::{Infallible, SeedableRng, TryRng};
 
 use super::Mt;
 
@@ -21,13 +21,13 @@ impl SeedableRng for Mt {
     /// # Examples
     ///
     /// ```
-    /// use rand_core::{RngCore, SeedableRng};
+    /// use rand_core::{Rng, SeedableRng};
     /// use rand_mt::Mt;
     ///
     /// // Default MT seed
     /// let seed = 5489_u32.to_le_bytes();
     /// let mut rng = Mt::from_seed(seed);
-    /// # fn example<T: RngCore>(mut rng: T) {
+    /// # fn example<T: Rng>(mut rng: T) {
     /// assert_ne!(rng.next_u32(), rng.next_u32());
     /// # }
     /// # example(rng);
@@ -38,7 +38,9 @@ impl SeedableRng for Mt {
     }
 }
 
-impl RngCore for Mt {
+impl TryRng for Mt {
+    type Error = Infallible;
+
     /// Generate next `u64` output.
     ///
     /// This function is implemented by generating two `u32`s from the RNG and
@@ -47,18 +49,18 @@ impl RngCore for Mt {
     /// # Examples
     ///
     /// ```
-    /// use rand_core::RngCore;
+    /// use rand_core::Rng;
     /// use rand_mt::Mt;
     ///
     /// let mut rng = Mt::new_unseeded();
-    /// # fn example<T: RngCore>(mut rng: T) {
+    /// # fn example<T: Rng>(mut rng: T) {
     /// assert_ne!(rng.next_u64(), rng.next_u64());
     /// # }
     /// # example(rng);
     /// ```
     #[inline]
-    fn next_u64(&mut self) -> u64 {
-        Self::next_u64(self)
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(Self::next_u64(self))
     }
 
     /// Generate next `u32` output.
@@ -69,18 +71,18 @@ impl RngCore for Mt {
     /// # Examples
     ///
     /// ```
-    /// use rand_core::RngCore;
+    /// use rand_core::Rng;
     /// use rand_mt::Mt;
     ///
     /// let mut rng = Mt::new_unseeded();
-    /// # fn example<T: RngCore>(mut rng: T) {
+    /// # fn example<T: Rng>(mut rng: T) {
     /// assert_ne!(rng.next_u32(), rng.next_u32());
     /// # }
     /// # example(rng);
     /// ```
     #[inline]
-    fn next_u32(&mut self) -> u32 {
-        Self::next_u32(self)
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(Self::next_u32(self))
     }
 
     /// Fill a buffer with bytes generated from the RNG.
@@ -94,11 +96,11 @@ impl RngCore for Mt {
     /// # Examples
     ///
     /// ```
-    /// use rand_core::RngCore;
+    /// use rand_core::Rng;
     /// use rand_mt::Mt;
     ///
     /// let mut rng = Mt::new_unseeded();
-    /// # fn example<T: RngCore>(mut rng: T) {
+    /// # fn example<T: Rng>(mut rng: T) {
     /// let mut buf = [0; 32];
     /// rng.fill_bytes(&mut buf);
     /// assert_ne!([0; 32], buf);
@@ -109,15 +111,16 @@ impl RngCore for Mt {
     /// # example(rng);
     /// ```
     #[inline]
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
         Self::fill_bytes(self, dest);
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use core::num::Wrapping;
-    use rand_core::{RngCore, SeedableRng};
+    use rand_core::{Rng, SeedableRng};
 
     use super::Mt;
     use crate::vectors::mt::{STATE_SEEDED_BY_U32, TEST_OUTPUT};
@@ -140,7 +143,7 @@ mod tests {
         let key = [0x123_u32, 0x234_u32, 0x345_u32, 0x456_u32];
         let mut rng = Mt::new_with_key(key.iter().copied());
         for &x in &TEST_OUTPUT {
-            assert_eq!(x, RngCore::next_u32(&mut rng));
+            assert_eq!(x, Rng::next_u32(&mut rng));
         }
     }
 }

--- a/src/mt64.rs
+++ b/src/mt64.rs
@@ -478,8 +478,8 @@ mod tests {
     use core::num::Wrapping;
 
     use super::{Mt64, NN};
-    use crate::vectors::mt64::{STATE_SEEDED_BY_SLICE, STATE_SEEDED_BY_U64, TEST_OUTPUT};
     use crate::RecoverRngError;
+    use crate::vectors::mt64::{STATE_SEEDED_BY_SLICE, STATE_SEEDED_BY_U64, TEST_OUTPUT};
 
     #[test]
     fn seeded_state_from_u64_seed() {

--- a/src/mt64/rand.rs
+++ b/src/mt64/rand.rs
@@ -9,7 +9,7 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use rand_core::{RngCore, SeedableRng};
+use rand_core::{Infallible, SeedableRng, TryRng};
 
 use super::Mt64;
 
@@ -21,7 +21,7 @@ impl SeedableRng for Mt64 {
     /// # Examples
     ///
     /// ```
-    /// # use rand_core::{RngCore, SeedableRng};
+    /// # use rand_core::{Rng, SeedableRng};
     /// # use rand_mt::Mt64;
     /// // Default MT seed
     /// let seed = 5489_u64.to_le_bytes();
@@ -34,7 +34,9 @@ impl SeedableRng for Mt64 {
     }
 }
 
-impl RngCore for Mt64 {
+impl TryRng for Mt64 {
+    type Error = Infallible;
+
     /// Generate next `u64` output.
     ///
     /// `u64` is the native output of the generator. This function advances the
@@ -43,18 +45,18 @@ impl RngCore for Mt64 {
     /// # Examples
     ///
     /// ```
-    /// use rand_core::RngCore;
+    /// use rand_core::Rng;
     /// use rand_mt::Mt64;
     ///
     /// let mut rng = Mt64::new_unseeded();
-    /// # fn example<T: RngCore>(mut rng: T) {
+    /// # fn example<T: Rng>(mut rng: T) {
     /// assert_ne!(rng.next_u64(), rng.next_u64());
     /// # }
     /// # example(rng);
     /// ```
     #[inline]
-    fn next_u64(&mut self) -> u64 {
-        Self::next_u64(self)
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(Self::next_u64(self))
     }
 
     /// Generate next `u32` output.
@@ -65,18 +67,18 @@ impl RngCore for Mt64 {
     /// # Examples
     ///
     /// ```
-    /// use rand_core::RngCore;
+    /// use rand_core::Rng;
     /// use rand_mt::Mt64;
     ///
     /// let mut rng = Mt64::new_unseeded();
-    /// # fn example<T: RngCore>(mut rng: T) {
+    /// # fn example<T: Rng>(mut rng: T) {
     /// assert_ne!(rng.next_u32(), rng.next_u32());
     /// # }
     /// # example(rng);
     /// ```
     #[inline]
-    fn next_u32(&mut self) -> u32 {
-        Self::next_u32(self)
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(Self::next_u32(self))
     }
 
     /// Fill a buffer with bytes generated from the RNG.
@@ -90,11 +92,11 @@ impl RngCore for Mt64 {
     /// # Examples
     ///
     /// ```
-    /// use rand_core::RngCore;
+    /// use rand_core::Rng;
     /// use rand_mt::Mt64;
     ///
     /// let mut rng = Mt64::new_unseeded();
-    /// # fn example<T: RngCore>(mut rng: T) {
+    /// # fn example<T: Rng>(mut rng: T) {
     /// let mut buf = [0; 32];
     /// rng.fill_bytes(&mut buf);
     /// assert_ne!([0; 32], buf);
@@ -105,15 +107,16 @@ impl RngCore for Mt64 {
     /// # example(rng);
     /// ```
     #[inline]
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
         Self::fill_bytes(self, dest);
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use core::num::Wrapping;
-    use rand_core::{RngCore, SeedableRng};
+    use rand_core::{Rng, SeedableRng};
 
     use super::Mt64;
     use crate::vectors::mt64::{STATE_SEEDED_BY_U64, TEST_OUTPUT};
@@ -136,7 +139,7 @@ mod tests {
         let key = [0x12345_u64, 0x23456_u64, 0x34567_u64, 0x45678_u64];
         let mut mt = Mt64::new_with_key(key.iter().copied());
         for &x in &TEST_OUTPUT {
-            assert_eq!(x, RngCore::next_u64(&mut mt));
+            assert_eq!(x, Rng::next_u64(&mut mt));
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR addresses https://github.com/artichoke/rand_mt/issues/305 by upgrading `rand_core` to `0.10.0` (upstream breaking change) and migrating this crate's trait implementations to the new `rand_core` API.

What changed:
- Bumped `rand_core` dependency from `0.9.0` to `0.10.0`.
- Replaced `RngCore` impls with `TryRng` impls (`Error = Infallible`) for `Mt` and `Mt64`, and updated call sites/docs to use `Rng`.
- Bumped MSRV from `1.81.0` to `1.85.0`.
- Updated crate docs/README wording from `RngCore` to `Rng`.
- Switched crate edition from Rust 2021 to Rust 2024.

Why Rust 2024 now:
- Issue #305 requires `rand_core` `0.10`, which raises MSRV to Rust `1.85`.
- Rust 2024 edition is stable as of Rust `1.85`, so once MSRV is raised to `1.85`, this crate can adopt edition 2024 without increasing the compiler floor further.

Upstream references:
- Source ticket: https://github.com/artichoke/rand_mt/issues/305
- rand_core `0.10.0`: https://crates.io/crates/rand_core/0.10.0

## Testing

- `cargo fmt --check`
- `cargo test`

## User Prompt

<details>
<summary>Address issue #305, include Rust 2024 edition upgrade, then branch/commit/PR with issue crosslink, CI polling, and merge</summary>

- `address this ticket https://github.com/artichoke/rand_mt/issues/305`
- `update to 2024 edition while we're at it`
- `make a git commit on a new branch, conventional commits style. link to the source ticket. then create a PR with these changes with gh CLI. include a "## User Prompt" section with a details block of all the prompts I gave you. summarize the prompt set in the <summary>`
- `the pr desc should indicate what changed and why with reference to upstream. indicate why we can now update to 2024 edition, link to the source ticket and also leave a comment on the source ticket crosslinking to this PR.`
- `use gh cli to poll the build. once tests are green, merge the PR`

</details>
