### PR TITLE
release!: bump rand_mt to v6.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_mt"
-version = "5.0.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "6.0.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = [
     "David Creswick <dcrewi@gyrae.net>",
     "Ryan Lopopolo <rjl@hyperbo.la>",
@@ -25,7 +25,7 @@ rand-traits = ["dep:rand_core"]
 rand_core = { version = "0.10.0", default-features = false, optional = true }
 
 [dev-dependencies]
-getrandom = { version = "0.3.1", default-features = false }
+getrandom = { version = "0.4.1", default-features = false }
 
 [package.metadata.docs.rs]
 # This sets the default target to `x86_64-unknown-linux-gnu` and only builds

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rand_mt = "5.0.0"
+rand_mt = "6.0.0"
 ```
 
 Then create a RNG like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@
 )]
 //! [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html"
 
-#![doc(html_root_url = "https://docs.rs/rand_mt/5.0.0")]
+#![doc(html_root_url = "https://docs.rs/rand_mt/6.0.0")]
 #![no_std]
 
 #[cfg(any(test, doctest))]


### PR DESCRIPTION
## Summary

This follow-up introduces the major release line for `rand_mt` and updates a dev-dependency.

What changed:
- Bumped crate version from `5.0.0` to `6.0.0` in `Cargo.toml`.
- Updated `html_root_url` to `https://docs.rs/rand_mt/6.0.0`.
- Updated README dependency snippet to `rand_mt = "6.0.0"`.
- Upgraded dev-dependency `getrandom` to the latest major: `0.4.1`.

Why:
- Upstream `rand_core` `0.10` is a breaking change and was adopted in the prior implementation PR.
- This PR makes that break explicit in crate semver by moving to `rand_mt 6.x`.
- `getrandom` was also updated to the latest major per follow-up request.

Upstream and source references:
- Source ticket: https://github.com/artichoke/rand_mt/issues/305
- Prior implementation PR: https://github.com/artichoke/rand_mt/pull/306
- `rand_core` `0.10.0`: https://crates.io/crates/rand_core/0.10.0
- `getrandom` `0.4.1`: https://crates.io/crates/getrandom/0.4.1

## Testing

- `cargo test`
- `npx prettier --check README.md`

## User Prompt

<details>
<summary>Create a follow-up major-version PR like before, plus bump getrandom dev-dep to latest major</summary>

- `please make a followup now which does a major version bump of this crate, make the pr etc in the same way`
- `oh also let's upgrade the dev dep to the latest major of getrandom please`

</details>



Closes #305
