### PR TITLE
Bump version to 6.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_mt"
-version = "6.0.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "6.0.1" # remember to set `html_root_url` in `src/lib.rs`.
 authors = [
     "David Creswick <dcrewi@gyrae.net>",
     "Ryan Lopopolo <rjl@hyperbo.la>",

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rand_mt = "6.0.0"
+rand_mt = "6.0.1"
 ```
 
 Then create a RNG like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@
 )]
 //! [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html"
 
-#![doc(html_root_url = "https://docs.rs/rand_mt/6.0.0")]
+#![doc(html_root_url = "https://docs.rs/rand_mt/6.0.1")]
 #![no_std]
 
 #[cfg(any(test, doctest))]


### PR DESCRIPTION
## Summary
- bump crate version from `6.0.0` to `6.0.1`
- update `html_root_url` to `https://docs.rs/rand_mt/6.0.1`
- update README dependency example to `rand_mt = "6.0.1"`

## Validation
- `cargo test`