### PR TITLE
Fix rustdoc build and prepare v6.0.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_mt"
-version = "6.0.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "6.0.2" # remember to set `html_root_url` in `src/lib.rs`.
 authors = [
     "David Creswick <dcrewi@gyrae.net>",
     "Ryan Lopopolo <rjl@hyperbo.la>",

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rand_mt = "6.0.1"
+rand_mt = "6.0.2"
 ```
 
 Then create a RNG like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@
 //
 // This approach is borrowed from tokio.
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, feature(doc_alias))]
 
 //! Mersenne Twister random number generators.
 //!
@@ -89,7 +88,7 @@
 )]
 //! [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html"
 
-#![doc(html_root_url = "https://docs.rs/rand_mt/6.0.1")]
+#![doc(html_root_url = "https://docs.rs/rand_mt/6.0.2")]
 #![no_std]
 
 #[cfg(any(test, doctest))]


### PR DESCRIPTION
## Summary
- remove the stale docsrs doc_alias feature gate that now fails under -D warnings
- bump the crate and docs metadata from 6.0.1 to 6.0.2
- update the README dependency snippet for the patch release

## Verification
- cargo test
- cargo +nightly test
- RUSTDOCFLAGS="-D warnings -D rustdoc::broken_intra_doc_links --cfg docsrs" cargo +nightly doc --no-deps
- cargo package --allow-dirty