### PR TITLE
[codex] Harden deterministic constructor docs for 6.0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_mt"
-version = "6.0.2" # remember to set `html_root_url` in `src/lib.rs`.
+version = "6.0.3" # remember to set `html_root_url` in `src/lib.rs`.
 authors = [
     "David Creswick <dcrewi@gyrae.net>",
     "Ryan Lopopolo <rjl@hyperbo.la>",

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ let mut rng = Mt64::new(0x0123_4567_89ab_cdef_u64);
 assert_ne!(rng.next_u64(), rng.next_u64());
 ```
 
-`Mt::new_unseeded()` and `Mt64::new_unseeded()` are deterministic shortcuts
-for the reference seed. They are intended for reproducible streams and tests
-and do not gather entropy.
+`Mt::new_unseeded()` and `Mt64::new_unseeded()` are deterministic shortcuts for
+the reference seed. They are intended for reproducible streams and tests and do
+not gather entropy.
 
 ## Crate Features
 

--- a/README.md
+++ b/README.md
@@ -32,17 +32,21 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rand_mt = "6.0.2"
+rand_mt = "6.0.3"
 ```
 
-Then create a RNG like:
+Then create a RNG with an explicit seed:
 
 ```rust
 use rand_mt::Mt64;
 
-let mut rng = Mt64::new_unseeded();
+let mut rng = Mt64::new(0x0123_4567_89ab_cdef_u64);
 assert_ne!(rng.next_u64(), rng.next_u64());
 ```
+
+`Mt::new_unseeded()` and `Mt64::new_unseeded()` are deterministic shortcuts
+for the reference seed. They are intended for reproducible streams and tests
+and do not gather entropy.
 
 ## Crate Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rand_mt"
-version = "6.0.2"
+version = "6.0.3"
 description = "Reference Mersenne Twister random number generators"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,15 +60,17 @@
 //! rng.fill_bytes(&mut buf);
 //! ```
 //!
-//! Or if you want to use the default (fixed) seeds that are specified in the
-//! reference implementations:
+//! Or if you want reproducible output from the default reference seed:
 //!
 //! ```
 //! # use rand_mt::Mt;
-//! let default = Mt::default();
-//! let mt = Mt::new_unseeded();
-//! assert_eq!(default, mt);
+//! let mut mt = Mt::new(Mt::DEFAULT_SEED);
+//! assert_ne!(mt.next_u32(), mt.next_u32());
 //! ```
+//!
+//! [`Mt::new_unseeded`] and [`Mt64::new_unseeded`] are deterministic shortcuts
+//! for the reference seed. They are intended for reproducible streams and
+//! tests and do not gather entropy.
 //!
 //! # Crate Features
 //!
@@ -88,7 +90,7 @@
 )]
 //! [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html"
 
-#![doc(html_root_url = "https://docs.rs/rand_mt/6.0.2")]
+#![doc(html_root_url = "https://docs.rs/rand_mt/6.0.3")]
 #![no_std]
 
 #[cfg(any(test, doctest))]

--- a/src/mt.rs
+++ b/src/mt.rs
@@ -235,6 +235,9 @@ impl Mt {
     /// Create a new Mersenne Twister random number generator using the default
     /// fixed seed.
     ///
+    /// This constructor is deterministic and intended for reproducible
+    /// streams, tests, and reference behavior. It does not gather entropy.
+    ///
     /// # Examples
     ///
     /// ```
@@ -260,7 +263,7 @@ impl Mt {
     ///
     /// ```
     /// # use rand_mt::Mt;
-    /// let mut mt = Mt::new_unseeded();
+    /// let mut mt = Mt::new(0x1234_5678_u32);
     /// assert_ne!(mt.next_u64(), mt.next_u64());
     /// ```
     #[inline]
@@ -279,7 +282,7 @@ impl Mt {
     ///
     /// ```
     /// # use rand_mt::Mt;
-    /// let mut mt = Mt::new_unseeded();
+    /// let mut mt = Mt::new(0x1234_5678_u32);
     /// assert_ne!(mt.next_u32(), mt.next_u32());
     /// ```
     #[inline]
@@ -307,7 +310,7 @@ impl Mt {
     ///
     /// ```
     /// # use rand_mt::Mt;
-    /// let mut mt = Mt::new_unseeded();
+    /// let mut mt = Mt::new(0x1234_5678_u32);
     /// let mut buf = [0; 32];
     /// mt.fill_bytes(&mut buf);
     /// assert_ne!([0; 32], buf);

--- a/src/mt/rand.rs
+++ b/src/mt/rand.rs
@@ -52,7 +52,7 @@ impl TryRng for Mt {
     /// use rand_core::Rng;
     /// use rand_mt::Mt;
     ///
-    /// let mut rng = Mt::new_unseeded();
+    /// let mut rng = Mt::new(0x1234_5678_u32);
     /// # fn example<T: Rng>(mut rng: T) {
     /// assert_ne!(rng.next_u64(), rng.next_u64());
     /// # }
@@ -74,7 +74,7 @@ impl TryRng for Mt {
     /// use rand_core::Rng;
     /// use rand_mt::Mt;
     ///
-    /// let mut rng = Mt::new_unseeded();
+    /// let mut rng = Mt::new(0x1234_5678_u32);
     /// # fn example<T: Rng>(mut rng: T) {
     /// assert_ne!(rng.next_u32(), rng.next_u32());
     /// # }
@@ -99,7 +99,7 @@ impl TryRng for Mt {
     /// use rand_core::Rng;
     /// use rand_mt::Mt;
     ///
-    /// let mut rng = Mt::new_unseeded();
+    /// let mut rng = Mt::new(0x1234_5678_u32);
     /// # fn example<T: Rng>(mut rng: T) {
     /// let mut buf = [0; 32];
     /// rng.fill_bytes(&mut buf);

--- a/src/mt64.rs
+++ b/src/mt64.rs
@@ -219,6 +219,9 @@ impl Mt64 {
     /// Create a new Mersenne Twister random number generator using the default
     /// fixed seed.
     ///
+    /// This constructor is deterministic and intended for reproducible
+    /// streams, tests, and reference behavior. It does not gather entropy.
+    ///
     /// # Examples
     ///
     /// ```
@@ -244,7 +247,7 @@ impl Mt64 {
     ///
     /// ```
     /// # use rand_mt::Mt64;
-    /// let mut mt = Mt64::new_unseeded();
+    /// let mut mt = Mt64::new(0x0123_4567_89ab_cdef_u64);
     /// assert_ne!(mt.next_u64(), mt.next_u64());
     /// ```
     #[inline]
@@ -269,7 +272,7 @@ impl Mt64 {
     ///
     /// ```
     /// # use rand_mt::Mt64;
-    /// let mut mt = Mt64::new_unseeded();
+    /// let mut mt = Mt64::new(0x0123_4567_89ab_cdef_u64);
     /// assert_ne!(mt.next_u32(), mt.next_u32());
     /// ```
     #[inline]
@@ -293,7 +296,7 @@ impl Mt64 {
     ///
     /// ```
     /// # use rand_mt::Mt64;
-    /// let mut mt = Mt64::new_unseeded();
+    /// let mut mt = Mt64::new(0x0123_4567_89ab_cdef_u64);
     /// let mut buf = [0; 32];
     /// mt.fill_bytes(&mut buf);
     /// assert_ne!([0; 32], buf);

--- a/src/mt64/rand.rs
+++ b/src/mt64/rand.rs
@@ -48,7 +48,7 @@ impl TryRng for Mt64 {
     /// use rand_core::Rng;
     /// use rand_mt::Mt64;
     ///
-    /// let mut rng = Mt64::new_unseeded();
+    /// let mut rng = Mt64::new(0x0123_4567_89ab_cdef_u64);
     /// # fn example<T: Rng>(mut rng: T) {
     /// assert_ne!(rng.next_u64(), rng.next_u64());
     /// # }
@@ -70,7 +70,7 @@ impl TryRng for Mt64 {
     /// use rand_core::Rng;
     /// use rand_mt::Mt64;
     ///
-    /// let mut rng = Mt64::new_unseeded();
+    /// let mut rng = Mt64::new(0x0123_4567_89ab_cdef_u64);
     /// # fn example<T: Rng>(mut rng: T) {
     /// assert_ne!(rng.next_u32(), rng.next_u32());
     /// # }
@@ -95,7 +95,7 @@ impl TryRng for Mt64 {
     /// use rand_core::Rng;
     /// use rand_mt::Mt64;
     ///
-    /// let mut rng = Mt64::new_unseeded();
+    /// let mut rng = Mt64::new(0x0123_4567_89ab_cdef_u64);
     /// # fn example<T: Rng>(mut rng: T) {
     /// let mut buf = [0; 32];
     /// rng.fill_bytes(&mut buf);


### PR DESCRIPTION
## Summary
- replace high-visibility `new_unseeded()` examples with explicit-seed examples
- document that `new_unseeded()` is deterministic and intended for reproducible streams and tests
- bump crate metadata and docs references to `6.0.3` to prep the next patch release

## Why
The security review tracked in #319 did not find any confirmed exploitable vulnerabilities, but it did identify a documentation-driven misuse risk: downstream users can cargo-cult deterministic constructors into sensitive code.

## Validation
- `cargo test`
- `cargo test --all-features`
- `cargo test --no-default-features`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`

Closes #319.