### PR TITLE
Warn on broad Clippy lint groups

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,9 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
-#![deny(clippy::cargo)]
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
 #![allow(unknown_lints)]
 #![deny(missing_debug_implementations)]
 #![warn(missing_docs)]


### PR DESCRIPTION
## Summary

Change the crate-root broad Clippy lint groups from deny to warn:

- clippy::all
- clippy::pedantic
- clippy::cargo

## Why

These broad Clippy groups are not stable project invariants. Keeping them as deny in crate attributes means new Clippy lints or toolchain drift can unexpectedly turn downstream builds into hard failures. CI can still promote warnings to errors for repository validation without exporting that policy through crate attributes.

## Validation

- /Users/lopopolo/.cargo/bin/cargo fmt --check
- /Users/lopopolo/.cargo/bin/cargo clippy --workspace --all-features --all-targets