### PR TITLE
Add docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,50 @@
+# Documentation
+
+This directory contains maintenance documentation for this crate.
+
+Use the crate `README.md` and crate docs for user-facing API documentation. Use
+`CONTRIBUTING.md` for local development setup and commands. Use this directory
+for project policy, guardrails, supply-chain posture, and recurring maintenance
+runbooks.
+
+## Guardrails
+
+[`guardrails/`](guardrails/README.md) contains durable review standards for
+common classes of work:
+
+- API stability, semver, MSRV, and release-impacting changes.
+- Rust implementation quality, lints, docs, and maintainability.
+- Testing, compatibility, conformance, and regression coverage.
+- Unsafe code, FFI, platform-specific behavior, and memory behavior.
+- Working in public and publishing OSS crates.
+
+Start with [`guardrails/README.md`](guardrails/README.md), then read the
+guardrail that matches the change.
+
+## Supply Chain
+
+[`dependencies.md`](dependencies.md) describes dependency policy, audit
+expectations, update posture, and how to evaluate dependency changes.
+
+Use it for dependency additions, version range changes, audit findings,
+Dependabot updates, and CI changes that affect dependency verification.
+
+## Automations
+
+[`automations/`](automations/README.md) contains runbooks for recurring
+maintenance.
+
+Use these docs when performing scheduled or mechanical work such as dependency
+sweeps, GitHub Actions runner updates, or optional dependency compatibility
+checks.
+
+For `rand_mt`, also see:
+
+- [`automations/rand-core.md`](automations/rand-core.md), for optional
+  `rand_core` compatibility maintenance.
+
+## Updating Docs
+
+Update docs in the same PR when a change alters public behavior, compatibility
+claims, feature behavior, MSRV, dependency policy, release process, automation
+behavior, or guardrail expectations.


### PR DESCRIPTION
## Summary

- Add `docs/README.md` as the entry point for maintenance documentation.
- Point readers to guardrails, dependency posture, and recurring automation runbooks.
- Call out the `rand_core` compatibility runbook for rand_mt-specific maintenance.

## Validation

- pnpm run fmt
- pnpm exec prettier --check "**/*"
- git diff --check

Rust tests were not run because this PR only changes documentation.