### PR TITLE
Document dependency sweep automerge flow

### DIFF
--- a/docs/automations/dependency-sweep.md
+++ b/docs/automations/dependency-sweep.md
@@ -12,6 +12,25 @@ or inbox follow-ups, should be reviewed and used to update these guardrails
 before repeating the same class of change. Automation-authored pull request
 comments must start with the stable prefix `Codex automation note:`.
 
+## Dependabot First
+
+Start every run by reviewing open pull requests created by Dependabot. If a
+Dependabot pull request has a mechanical dependency diff, is aligned with
+`docs/dependencies.md`, and has passing required checks, move it to GitHub
+auto-merge.
+
+Do not enable auto-merge for Dependabot pull requests that look high risk. Leave
+those for human review, assign the pull request to `lopopolo` when practical,
+and add a short `Codex automation note:` comment explaining the reason if it is
+not already clear from the pull request.
+
+If any Dependabot pull request is moved to auto-merge, wait until GitHub merges
+it and the repository primary branch contains the merge. When multiple
+Dependabot pull requests are accepted, wait for the primary branch to include
+all accepted merges. Then fetch the updated primary branch and rebase the
+automation workspace onto it before scanning for additional dependency updates
+or creating automation-owned branches.
+
 ## Scope
 
 The sweep owns dependency maintenance that is not covered well by Dependabot:
@@ -47,11 +66,6 @@ action instead of Corepack.
 
 ## Workflow
 
-Start every run by reviewing open Dependabot pull requests. If a Dependabot pull
-request is mechanical, aligned with the dependency posture, and passing CI, it
-may be moved to auto-merge. Leave risky updates for human review with a short
-comment explaining why.
-
 For automation-owned updates:
 
 - use authoritative upstream release metadata;
@@ -69,9 +83,34 @@ from this automation must include the `A-deps`, `C-automation`, and `codex`
 labels. Do not enable auto-merge for high-risk updates, failed validation,
 unclear release notes, or non-mechanical migrations.
 
+Treat these as high risk:
+
+- major version bumps for hand-curated tooling pins or runtime-sensitive
+  dependencies;
+- unclear or missing release notes;
+- security-sensitive dependency changes;
+- non-mechanical migrations;
+- failed formatting, linting, tests, or validation;
+- broad behavioral changes that are hard to reason about from the diff.
+
+For Dependabot-managed manifest and lockfile updates, do not treat a major
+version bump as automatically high risk when the diff is mechanical, no
+repository code or configuration changes are needed beyond the version bump, and
+validation passes. Judge those updates by observed impact and relevant
+compatibility notes instead of the semver label alone.
+
 Each pull request should summarize:
 
 - old and new versions or lockfile refresh scope;
 - cooldown decisions;
 - validation commands and results;
 - any Dependabot pull requests reviewed, merged, or intentionally left alone.
+
+Open an inbox item summarizing:
+
+- Dependabot pull requests moved to auto-merge and any primary-branch rebase;
+- Dependabot pull requests left for human review and the reasons;
+- automation-owned dependency pull requests created;
+- which pull requests had auto-merge enabled;
+- which pull requests were assigned for human review;
+- failed or skipped validation.


### PR DESCRIPTION
## Summary

- Document the Dependabot-first review path for the dependency sweep automation.
- Add explicit high-risk criteria and human-review handling.
- Require inbox summaries for auto-merge decisions, PRs, assignments, and skipped validation.

## Change Class

Dependencies, CI, and automation documentation.

## Compatibility Impact

No crate API, generator behavior, deterministic output, Ruby compatibility, `no_std`, feature, or MSRV behavior changes. This is a docs-only automation runbook update.

## Validation

- `mise exec -- pnpm run fmt`

The app automation `rand-mt-dependency-sweep` was created separately. No dependency PR work was run.