### PR TITLE
Pin Ubuntu runner labels

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   rust:
     name: Audit Rust Dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         checks:
@@ -58,7 +58,7 @@ jobs:
 
   zizmor:
     name: Run zizmor 🌈
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read # required to checkout repository
       security-events: write # required to add findings via sarif

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
 
   build-msrv:
     name: Build (MSRV)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: 1
@@ -95,7 +95,7 @@ jobs:
 
   rust:
     name: Lint and format Rust
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: 1
@@ -144,7 +144,7 @@ jobs:
 
   text:
     name: Lint and format text
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ jobs:
   crates-io:
     name: Publish to crates.io
     if: github.event.created == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: crates-io-publish
     permissions:

--- a/.github/workflows/repo-labels.yaml
+++ b/.github/workflows/repo-labels.yaml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   labels:
     name: Synchronize repository labels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read # required to checkout
       issues: write # required to create and destroy labels


### PR DESCRIPTION
## Summary

- Pin single-OS CI, audit, publish, and repository-label workflow jobs from `ubuntu-latest` to `ubuntu-24.04`.
- Leave the cross-platform build matrix on explicit GA/current labels: `ubuntu-24.04`, `windows-2025-vs2026`, and `macos-26`.
- Do not adopt `ubuntu-26.04` while GitHub marks it as preview.

## Change class and compatibility impact

Change class: Dependencies, CI, and Automation.

Compatibility impact: workflow-only. This does not affect the Rust crate API, MSRV, deterministic output sequences, Ruby compatibility, `no_std`, or `rand_core` integration.

## Runner image sources checked

- `actions/runner-images` README: `ubuntu-latest` currently maps to `ubuntu-24.04`; `ubuntu-26.04` is preview; `windows-2025-vs2026` and `macos-26` are available labels.
- `actions/runner-images` announcement #14254: Ubuntu 22.04 deprecation starts September 17, 2026; retirement is April 17, 2027.
- `actions/runner-images` announcement #14226: Ubuntu 26.04 became public preview on June 11, 2026.
- `actions/runner-images` announcement #14167: `macos-latest` migrates to `macos-26` from June 15, 2026 through July 15, 2026.
- `actions/runner-images` announcement #14017: `windows-latest` and `windows-2025` migrate to Windows Server 2025 with Visual Studio 2026 from June 8, 2026 through June 15, 2026.

## Branch rulesets

Inspected required status check contexts on `protect default branch from destructive actions`:

- `Audit Rust Dependencies (bans licenses sources)`
- `Lint and format Rust`
- `Build (macos-26)`
- `Build (ubuntu-24.04)`
- `Build (windows-2025-vs2026)`
- `Lint and format text`

No required-check context changes are needed because job names did not change.

## Validation

- `git diff --check`
- `mise exec -- pnpm exec prettier --check '**/*'`

`actionlint` was not available locally, so workflow-specific linting was skipped.
