### PR TITLE
ci: run audits only when relevant

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,9 +1,6 @@
 ---
 name: Audit
 "on":
-  push:
-    branches:
-      - trunk
   pull_request:
     branches:
       - trunk
@@ -14,19 +11,64 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
+  changes:
+    name: Detect relevant changes
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read # required to checkout repository
+    outputs:
+      rust: ${{ steps.changes.outputs.rust }}
+      workflows: ${{ steps.changes.outputs.workflows }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect relevant changes
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed_files="$(git diff --name-only "$BASE_SHA...$HEAD_SHA")"
+          rust=false
+          workflows=false
+
+          while IFS= read -r file; do
+            if [[ "$file" == *.rs ||
+                  "$file" == "Cargo.toml" ||
+                  "$file" == "Cargo.lock" ||
+                  "$file" == "deny.toml" ||
+                  "$file" == "mise.toml" ||
+                  "$file" == ".github/workflows/audit.yaml" ]]; then
+              rust=true
+            fi
+            if [[ "$file" == .github/workflows/* ||
+                  "$file" == "mise.toml" ]]; then
+              workflows=true
+            fi
+          done <<< "$changed_files"
+
+          printf 'rust=%s\n' "$rust" >> "$GITHUB_OUTPUT"
+          printf 'workflows=%s\n' "$workflows" >> "$GITHUB_OUTPUT"
+
   rust:
     name: Audit Rust Dependencies
+    needs: changes
+    if: >-
+      always() &&
+      (github.event_name == 'schedule' || needs.changes.outputs.rust == 'true')
     runs-on: ubuntu-24.04
+    # Preserve the existing matrix-suffixed check context for merge policy.
     strategy:
       matrix:
         checks:
-          - advisories
           - bans licenses sources
     permissions:
       contents: read # required to checkout repository
-
-    # Prevent sudden announcement of a new advisory from failing ci:
-    continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
       - name: Checkout repository
@@ -50,7 +92,16 @@ jobs:
             cargo generate-lockfile --verbose
           fi
 
-      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+      - name: Audit advisories
+        continue-on-error: true
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+        with:
+          arguments: --locked --all-features
+          command: check advisories
+          command-arguments: --show-stats
+
+      - name: Audit bans, licenses, and sources
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
         with:
           arguments: --locked --all-features
           command: check ${{ matrix.checks }}
@@ -58,6 +109,11 @@ jobs:
 
   zizmor:
     name: Run zizmor 🌈
+    needs: changes
+    if: >-
+      always() &&
+      (github.event_name == 'schedule' ||
+      needs.changes.outputs.workflows == 'true')
     runs-on: ubuntu-24.04
     permissions:
       contents: read # required to checkout repository

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -62,11 +62,6 @@ jobs:
       always() &&
       (github.event_name == 'schedule' || needs.changes.outputs.rust == 'true')
     runs-on: ubuntu-24.04
-    # Preserve the existing matrix-suffixed check context for merge policy.
-    strategy:
-      matrix:
-        checks:
-          - bans licenses sources
     permissions:
       contents: read # required to checkout repository
 
@@ -104,7 +99,7 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
         with:
           arguments: --locked --all-features
-          command: check ${{ matrix.checks }}
+          command: check bans licenses sources
           command-arguments: --show-stats
 
   zizmor:


### PR DESCRIPTION
## Summary

- run Rust dependency audits only for Rust source, manifest, lockfile, policy, toolchain, or audit-workflow changes
- run zizmor only for workflow or toolchain changes
- retain the weekly audit while skipping its change-detector runner
- combine cargo-deny checks on one runner and preserve the ruleset-required check context

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run fmt:check`
- `zizmor --pedantic .github/workflows`
- workflow trigger, matrix, and required-context assertions
